### PR TITLE
Weaktable based function cache

### DIFF
--- a/TypeShim/MarshallArgumentsTable.cs
+++ b/TypeShim/MarshallArgumentsTable.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace TypeShim;
+
+public static class MarshallArgumentsTable
+{
+    private static readonly ConditionalWeakTable<Type, ConditionalWeakTable<object, object>> _typeTables = new();
+
+    public static T GetOrCreate<T>(object target, Func<T> factory) where T : class
+    {
+        ConditionalWeakTable<object, object> table = _typeTables.GetValue(typeof(T), _ => new ConditionalWeakTable<object, object>());
+        return (T)table.GetValue(target, _ => factory()!);
+    }
+}


### PR DESCRIPTION
Enable caching output instances that've been modified for type transformations
- Preserves identity on the js side (passing `==`)
- Avoids unnecessary duplicate allocations (reduce memory use)
- Does not interfere with GC by using weak refs

> :warning: blocked by the fact that the interopservices.javascript lib does not in fact preserve identity by allocating new delegates for every interop invocation.