### PR TITLE
Library initializer instead of manual initialization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,9 +129,9 @@ jobs:
         id: badge
         shell: pwsh
         run: |
-          $path = if ("${{ fromJSON(steps.test-results.outputs.json).conclusion }}" -eq "success") { '#26cc23' } else { '#cc5623' }
+          $color = if ("${{ fromJSON(steps.test-results.outputs.json).conclusion }}" -eq "success") { '#26cc23' } else { '#cc5623' }
           $message = if ("${{ fromJSON(steps.test-results.outputs.json).conclusion }}" -eq "success") { "${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.runs_succ }} passing" } else { "${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.runs_fail }}/${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.runs }} failing" }
-          "color=$path" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "color=$color" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "message=$message" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
   benchmarks:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,7 @@ jobs:
           -p:Version=${{ needs.version.outputs.version }}
           -p:ContinuousIntegrationBuild=true
 
-      - name: Push to GitHub Packages
+      - name: Push to NuGet.org
         if: ${{ !inputs.dry-run }}
         run: >
           dotnet nuget push 
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update badge
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@v1.9.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: '0f24ed28316a25f6293d5771a247f19d'

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ TypeShim generates strongly-typed interop code for both C# & TypeScript, tailore
 
 [Check out the sample project](https://github.com/ArcadeMode/TypeShim/blob/master/sample/README.md) to see TypeShim in action. The snippets below also give a general idea of its capabilities.
 
-The snippets compare TypeShim vs manual `JSExport`. Whichever you use, you'll have load your wasm browser app as [described in the docs](https://learn.microsoft.com/en-us/aspnet/core/client-side/dotnet-interop/wasm-browser-app?view=aspnetcore-10.0#javascript-interop-on-). The runtime created by `dotnet.create()` can be passed directly into the provided `TypeShimInitializer`'s `initialize` method. The initializer exists so that helper functions for type marshalling can be set up and a reference to the assembly exports can be retrieved for the generated types to use internally.
+The snippets compare TypeShim vs manual `JSExport`. Whichever you use, you'll have load your wasm browser app as [described in the docs](https://learn.microsoft.com/en-us/aspnet/core/client-side/dotnet-interop/wasm-browser-app?view=aspnetcore-10.0#javascript-interop-on-).
 
 ### TypeShim
 A simple example where we have an app about 'people', just to show basic language use powered by TypeShim.
@@ -69,15 +69,13 @@ public class Person
 }
 ```
 
-On the TypeScript side things look familiar, class names, properties, methods and constructors all resemble the exported C# classes. Note the aforementioned TypeShimInitializer being called before engaging with the generated types. 
+On the TypeScript side things look familiar, class names, properties, methods and constructors all resemble the exported C# classes. 
 
 ```js
-import { TypeShimInitializer, PeopleRepository, Person } from './typeshim.ts';
+import { PeopleRepository, Person } from './typeshim.ts';
 
 public async UsingTypeShim() {
     const runtime = await dotnet.withApplicationArguments(args).create()
-    await TypeShimInitializer.initialize(runtime);
-
     const repository = new PeopleRepository();
     const alice: Person = repository.GetPerson(0);
     const bob = new Person({

--- a/src/TypeShim.E2E/vitest/src/setup/setup.ts
+++ b/src/TypeShim.E2E/vitest/src/setup/setup.ts
@@ -1,14 +1,11 @@
 import { beforeAll } from 'vitest';
 import { dotnet } from '_framework/dotnet';
-import { TypeShimInitializer } from 'typeshim';
 
 beforeAll(async () => {
   await initializeWASMRuntime();
 });
 
-let runtimeInfo: any = undefined;
 async function initializeWASMRuntime(): Promise<void> {
-  runtimeInfo = await dotnet.create();
-  await TypeShimInitializer.initialize(runtimeInfo);
+  const runtimeInfo = await dotnet.create();
   runtimeInfo.runMain();
 }

--- a/src/TypeShim.Generator/Typescript/TypeScriptPreambleRenderer.cs
+++ b/src/TypeShim.Generator/Typescript/TypeScriptPreambleRenderer.cs
@@ -11,28 +11,14 @@ internal class TypeScriptPreambleRenderer(RenderContext ctx)
 
     private const string Preamble = """
 class TypeShimConfig {
-  private static _exports: AssemblyExports | null = null;
-
   static get exports() {
-    if (!TypeShimConfig._exports) {
+    const state = globalThis[Symbol.for("@typeshim")] as { exports: AssemblyExports } | undefined;
+    if (!state?.exports) {
       throw new Error("TypeShim has not been initialized.");
     }
-    return TypeShimConfig._exports;
-  }
-
-  static async initialize(runtimeInfo: any) {
-    if (TypeShimConfig._exports){
-      throw new Error("TypeShim has already been initialized.");
-    }
-
-    runtimeInfo.setModuleImports("@typeshim", { 
-      unwrapProperty: (obj: any, propertyName: string) => obj[propertyName],
-    });
-    TypeShimConfig._exports = await runtimeInfo.getAssemblyExports(runtimeInfo.getConfig().mainAssemblyName);
+    return state.exports;
   }
 }
-
-export const TypeShimInitializer = { initialize: TypeShimConfig.initialize };
 
 const proxyMap = new WeakMap<ManagedObject, ProxyBase>();
 abstract class ProxyBase {

--- a/src/TypeShim/TypeShim.csproj
+++ b/src/TypeShim/TypeShim.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/TypeShim/wwwroot/TypeShim.lib.module.js
+++ b/src/TypeShim/wwwroot/TypeShim.lib.module.js
@@ -1,0 +1,16 @@
+﻿const moduleName = "@typeshim";
+const STATE_KEY = Symbol.for(moduleName);
+
+export async function onRuntimeReady({ setModuleImports, getAssemblyExports, getConfig }) {
+    const state = globalThis[STATE_KEY] ??= {};
+
+    if (state.exports) {
+        console.warn("TypeShim is already configured for another dotnet runtime, this will be an issue if you are trying to use multiple runtimes simultaneously.");
+    }
+    console.log("TypeShim is configuring module imports for dotnet runtime.");
+    setModuleImports(moduleName, {
+        unwrapProperty: (obj, propertyName) => obj[propertyName],
+    });
+    state.exports = await getAssemblyExports(getConfig().mainAssemblyName);
+    console.log("TypeShim is configured for dotnet runtime.");
+}

--- a/src/TypeShim/wwwroot/TypeShim.lib.module.js
+++ b/src/TypeShim/wwwroot/TypeShim.lib.module.js
@@ -2,15 +2,15 @@
 const STATE_KEY = Symbol.for(moduleName);
 
 export async function onRuntimeReady({ setModuleImports, getAssemblyExports, getConfig }) {
-    const state = globalThis[STATE_KEY] ??= {};
-
+    const state = globalThis[STATE_KEY] ?? {};
     if (state.exports) {
         console.warn("TypeShim is already configured for another dotnet runtime, this will be an issue if you are trying to use multiple runtimes simultaneously.");
     }
-    console.log("TypeShim is configuring module imports for dotnet runtime.");
+
     setModuleImports(moduleName, {
         unwrapProperty: (obj, propertyName) => obj[propertyName],
     });
+
     state.exports = await getAssemblyExports(getConfig().mainAssemblyName);
-    console.log("TypeShim is configured for dotnet runtime.");
+    globalThis[STATE_KEY] = state;
 }


### PR DESCRIPTION
Deprecate `TypeShimInitializer.initialize` in favour of `TypeShim.lib.module.js` with `onRuntimeReady` hook