### PR TITLE
Fix MSBuild FileWrites + drop CleanGeneratedCs target

### DIFF
--- a/src/TypeShim/TypeShim.targets
+++ b/src/TypeShim/TypeShim.targets
@@ -15,10 +15,6 @@
     </GenerateComputedBuildStaticWebAssetsDependsOn>
   </PropertyGroup>
 
-  <Target Name="TypeShimCleanGeneratedCs" BeforeTargets="TypeShimGenerateInterop" Condition="'$(DesignTimeBuild)' != 'true'">
-    <RemoveDir Directories="$(IntermediateOutputPath)/$(TypeShim_GeneratedDir)" />
-  </Target>
-
   <Target Name="TypeShimResolveTargetingPackRefDir" AfterTargets="ResolveAssemblyReferences">
     <!-- Filter resolved compile-time references to find System.Runtime.dll (and with it, the current targeting pack dir) -->
     <ItemGroup>

--- a/src/TypeShim/TypeShim.targets
+++ b/src/TypeShim/TypeShim.targets
@@ -104,6 +104,7 @@
     
     <ItemGroup>
       <Compile Include="$(_TypeShim_CSharpOutputDirectoryPath)/*.cs" />
+      <FileWrites Include="$(_TypeShim_TypeScriptOutputFilePath)" />
       <FileWrites Include="$(_TypeShim_TypeScriptOutputFilePathTemp)" />
     </ItemGroup>
   </Target>
@@ -162,8 +163,5 @@
       DestinationFiles="$(_TypeShim_TypeScriptOutputFilePath)"
       SkipUnchangedFiles="true"
       OverwriteReadOnlyFiles="true" />
-    <ItemGroup>
-      <FileWrites Include="$(_TypeShim_TypeScriptOutputFilePath)" />
-    </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
MSBuild didnt see the filewrite of the final ts file write, causing delete+recreate behavior, which in turn tripped up dev servers again. Register earlier so MSBuild doesnt delete the files.