### PR TITLE
chore: Refactor instance param injection

### DIFF
--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_Constructors.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_Constructors.cs
@@ -53,7 +53,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Number>]
     public static int get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     public static C1 FromObject(object obj)
@@ -111,7 +111,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Number>]
     public static int get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     public static C1 FromObject(object obj)
@@ -173,14 +173,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Number>]
     public static int get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Number>] int value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.P1 = value;
     }
     public static C1 FromObject(object obj)
@@ -251,7 +251,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Number>]
     public static int get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     public static C1 FromObject(object obj)
@@ -322,14 +322,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Number>]
     public static int get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Number>] int value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.P1 = value;
     }
     public static C1 FromObject(object obj)
@@ -391,7 +391,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Number>]
     public static int get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     public static C1 FromObject(object obj)
@@ -464,7 +464,7 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Number>]
             public static int get_P1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return typed_instance.P1;
             }
             public static C1 FromObject(object obj)
@@ -537,7 +537,7 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Number>]
             public static int get_P1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return typed_instance.P1;
             }
             public static C1 FromObject(object obj)
@@ -612,14 +612,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Any>]
     public static object get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return (object)typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Any>] object value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         UserClass typed_value = UserClassInterop.FromObject(value);
         typed_instance.P1 = typed_value;
     }

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_Delegates.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_Delegates.cs
@@ -53,7 +53,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Void>]
     public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function>] Action callback)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.M1(callback);
     }
     public static C1 FromObject(object obj)
@@ -111,7 +111,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Void>]
     public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function<JSType.String>>] Action<string> callback)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.M1(callback);
     }
     public static C1 FromObject(object obj)
@@ -169,7 +169,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Void>]
     public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function<JSType.String, JSType.Number>>] Action<string, int> callback)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.M1(callback);
     }
     public static C1 FromObject(object obj)
@@ -227,7 +227,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Void>]
     public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function<JSType.String, JSType.Number, JSType.Boolean>>] Action<string, int, bool> callback)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.M1(callback);
     }
     public static C1 FromObject(object obj)
@@ -285,7 +285,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.String>]
     public static string M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function<JSType.String>>] Func<string> callback)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.M1(callback);
     }
     public static C1 FromObject(object obj)
@@ -343,7 +343,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.String>]
     public static string M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function<JSType.String, JSType.Number>>] Func<string, int> callback)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.M1(callback);
     }
     public static C1 FromObject(object obj)
@@ -401,7 +401,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.String>]
     public static string M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function<JSType.String, JSType.Number, JSType.Boolean>>] Func<string, int, bool> callback)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.M1(callback);
     }
     public static C1 FromObject(object obj)
@@ -470,7 +470,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Void>]
     public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function<JSType.Any>>] Action<object> callback)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         Action<MyClass> typed_callback = (MyClass arg0) => callback(arg0);
         typed_instance.M1(typed_callback);
     }
@@ -540,7 +540,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Function<JSType.Any>>]
     public static Action<object> M1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         Action<MyClass> retVal = typed_instance.M1();
         return (object arg0) => retVal(MyClassInterop.FromObject(arg0));
     }
@@ -610,7 +610,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Function<JSType.Any, JSType.Any>>]
     public static Func<object, object> M1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         Func<MyClass, MyClass> retVal = typed_instance.M1();
         return (object arg0) => (object)retVal(MyClassInterop.FromObject(arg0));
     }
@@ -680,7 +680,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Function<JSType.Number, JSType.Any>>]
     public static Func<int, object?> M1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         Func<int, MyClass?> retVal = typed_instance.M1();
         return (int arg0) => (object?)retVal(arg0);
     }
@@ -750,7 +750,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Function<JSType.Any>>]
     public static Func<object?> M1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         Func<MyClass?> retVal = typed_instance.M1();
         return () => (object?)retVal();
     }
@@ -820,7 +820,7 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Void>]
             public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function<JSType.Number, JSType.Any>>] Func<int, object?> func)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 Func<int, MyClass?> typed_func = (int arg0) => func(arg0) is { } funcVal ? MyClassInterop.FromObject(funcVal) : null;
                 typed_instance.M1(typed_func);
             }
@@ -890,7 +890,7 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Void>]
             public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function<JSType.Any>>] Func<object?> func)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 Func<MyClass?> typed_func = () => func() is { } funcVal ? MyClassInterop.FromObject(funcVal) : null;
                 typed_instance.M1(typed_func);
             }
@@ -963,7 +963,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Any>]
     public static object M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function<JSType.Any, JSType.Any>>] Func<object, object> func, [JSMarshalAs<JSType.Function<JSType.Any>>] Func<object> paramFunc)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         Func<MyClass, MyClass> typed_func = (MyClass arg0) => MyClassInterop.FromObject(func(arg0));
         Func<MyClass> typed_paramFunc = () => MyClassInterop.FromObject(paramFunc());
         return (object)typed_instance.M1(typed_func, typed_paramFunc);
@@ -1039,7 +1039,7 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Function<JSType.Any, JSType.Any>>]
             public static Func<object, object> get_P1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 Func<MyClass, MyClass> retVal = typed_instance.P1;
                 return (object arg0) => (object)retVal(MyClassInterop.FromObject(arg0));
             }
@@ -1047,7 +1047,7 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Void>]
             public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function<JSType.Any, JSType.Any>>] Func<object, object> value)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 Func<MyClass, MyClass> typed_value = (MyClass arg0) => MyClassInterop.FromObject(value(arg0));
                 typed_instance.P1 = typed_value;
             }
@@ -1120,14 +1120,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Function>]
     public static Action get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function>] Action value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.P1 = value;
     }
     public static C1 FromObject(object obj)
@@ -1198,14 +1198,14 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Function<JSType.String>>]
             public static Action<char> get_P1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return typed_instance.P1;
             }
             [JSExport]
             [return: JSMarshalAs<JSType.Void>]
             public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Function<JSType.String>>] Action<char> value)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 typed_instance.P1 = value;
             }
             public static C1 FromObject(object obj)

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_Enums.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_Enums.cs
@@ -290,7 +290,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Number>]
     public static long Echo([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Number>] long b)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         Big typed_b = (Big)b;
         return (long)typed_instance.Echo(typed_b);
     }
@@ -491,14 +491,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Number>]
     public static int get_Scalar([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return (int)typed_instance.Scalar;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_Scalar([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Number>] int value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         Color typed_value = (Color)value;
         typed_instance.Scalar = typed_value;
     }
@@ -506,14 +506,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Number>]
     public static int? get_Nullable([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return (int?)typed_instance.Nullable;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_Nullable([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Number>] int? value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         Color? typed_value = value is { } valueVal ? (Color)valueVal : null;
         typed_instance.Nullable = typed_value;
     }
@@ -521,14 +521,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Array<JSType.Number>>]
     public static int[] get_Arr([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return Array.ConvertAll(typed_instance.Arr, e => (int)e);
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_Arr([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Array<JSType.Number>>] int[] value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         Color[] typed_value = Array.ConvertAll(value, e => (Color)e);
         typed_instance.Arr = typed_value;
     }

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_Properties.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_Properties.cs
@@ -68,14 +68,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Any>]
     public static object get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return (object)typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Any>] object value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         MyClass typed_value = MyClassInterop.FromObject(value);
         typed_instance.P1 = typed_value;
     }
@@ -225,14 +225,14 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Any>]
             public static object? get_P1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return (object?)typed_instance.P1;
             }
             [JSExport]
             [return: JSMarshalAs<JSType.Void>]
             public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Any>] object? value)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 MyClass? typed_value = value is { } valueVal ? MyClassInterop.FromObject(valueVal) : null;
                 typed_instance.P1 = typed_value;
             }
@@ -304,14 +304,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Any>]
     public static object get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Any>] object value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.P1 = value;
     }
     public static C1 FromObject(object obj)
@@ -382,14 +382,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Array<JSType.Number>>]
     public static int[] get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Array<JSType.Number>>] int[] value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.P1 = value;
     }
     public static C1 FromObject(object obj)
@@ -460,14 +460,14 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.MemoryView>]
             public static ArraySegment<int> get_P1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return typed_instance.P1;
             }
             [JSExport]
             [return: JSMarshalAs<JSType.Void>]
             public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.MemoryView>] ArraySegment<int> value)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 typed_instance.P1 = value;
             }
             public static C1 FromObject(object obj)
@@ -552,14 +552,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Array<JSType.Any>>]
     public static object[] get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return (object[])typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Array<JSType.Any>>] object[] value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         MyClass[] typed_value = Array.ConvertAll(value, e => MyClassInterop.FromObject(e));
         typed_instance.P1 = typed_value;
     }
@@ -645,14 +645,14 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Array<JSType.Any>>]
             public static object?[] get_P1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return (object?[])typed_instance.P1;
             }
             [JSExport]
             [return: JSMarshalAs<JSType.Void>]
             public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Array<JSType.Any>>] object?[] value)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 MyClass?[] typed_value = Array.ConvertAll(value, e => e is { } eVal ? MyClassInterop.FromObject(eVal) : null);
                 typed_instance.P1 = typed_value;
             }
@@ -737,14 +737,14 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Array<JSType.Any>>]
             public static object[]? get_P1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return (object[]?)typed_instance.P1;
             }
             [JSExport]
             [return: JSMarshalAs<JSType.Void>]
             public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Array<JSType.Any>>] object[]? value)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 MyClass[]? typed_value = value is { } valueVal ? Array.ConvertAll(valueVal, e => MyClassInterop.FromObject(e)) : null;
                 typed_instance.P1 = typed_value;
             }
@@ -830,14 +830,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Array<JSType.Any>>]
     public static object?[]? get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return (object?[]?)typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Array<JSType.Any>>] object?[]? value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         MyClass?[]? typed_value = value is { } valueVal ? Array.ConvertAll(valueVal, e => e is { } eVal ? MyClassInterop.FromObject(eVal) : null) : null;
         typed_instance.P1 = typed_value;
     }
@@ -923,14 +923,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Promise<JSType.Any>>]
     public static Task<object> get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1.ContinueWith(t => (object)t.Result, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Promise<JSType.Any>>] Task<object> value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         Task<MyClass> typed_value = value.ContinueWith(t => MyClassInterop.FromObject(t.Result), TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         typed_instance.P1 = typed_value;
     }
@@ -1016,14 +1016,14 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Promise<JSType.Any>>]
             public static Task<object?> get_P1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return typed_instance.P1.ContinueWith(t => (object?)t.Result, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
             }
             [JSExport]
             [return: JSMarshalAs<JSType.Void>]
             public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Promise<JSType.Any>>] Task<object?> value)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 Task<MyClass?> typed_value = value.ContinueWith(t => t.Result is { } tVal ? MyClassInterop.FromObject(tVal) : null, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
                 typed_instance.P1 = typed_value;
             }
@@ -1109,14 +1109,14 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Promise<JSType.Any>>]
             public static Task<object?>? get_P1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return typed_instance.P1?.ContinueWith(t => (object?)t.Result, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
             }
             [JSExport]
             [return: JSMarshalAs<JSType.Void>]
             public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Promise<JSType.Any>>] Task<object?>? value)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 Task<MyClass?>? typed_value = value?.ContinueWith(t => t.Result is { } tVal ? MyClassInterop.FromObject(tVal) : null, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
                 typed_instance.P1 = typed_value;
             }
@@ -1189,14 +1189,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Array<JSType.Any>>]
     public static object[] get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return (object[])typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Array<JSType.Any>>] object[] value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         {{typeName}}[] typed_value = ({{typeName}}[])value;
         typed_instance.P1 = typed_value;
     }

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_Snapshots.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_Snapshots.cs
@@ -61,14 +61,14 @@ public partial class C1Interop
     [return: JSMarshalAs<{{jsType}}>]
     public static {{typeExpression}} get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<{{jsType}}>] {{typeExpression}} value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.P1 = value;
     }
     public static C1 FromObject(object obj)
@@ -144,14 +144,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Array<JSType.Any>>]
     public static object[] get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return (object[])typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Array<JSType.Any>>] object[] value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         {{typeName}}[] typed_value = ({{typeName}}[])value;
         typed_instance.P1 = typed_value;
     }
@@ -159,14 +159,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Number>]
     public static int get_P2([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P2;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P2([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Number>] int value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.P2 = value;
     }
     public static C1 FromObject(object obj)
@@ -241,14 +241,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Promise<JSType.Any>>]
     public static Task<object> get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1.ContinueWith(t => (object)t.Result, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Promise<JSType.Any>>] Task<object> value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         Task<{{typeName}}> typed_value = value.ContinueWith(t => ({{typeName}})t.Result, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         typed_instance.P1 = typed_value;
     }
@@ -256,14 +256,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Number>]
     public static int get_P2([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P2;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P2([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Number>] int value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.P2 = value;
     }
     public static C1 FromObject(object obj)

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemArrayReturnType.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemArrayReturnType.cs
@@ -195,7 +195,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Promise<JSType.Any>>]
     public static Task<object> M1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.M1().ContinueWith(t => (object)t.Result, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
     }
     public static C1 FromObject(object obj)

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemDateTimeParameterType.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemDateTimeParameterType.cs
@@ -94,7 +94,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Void>]
     public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Date>] {{interopTypeExpression}} p1)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.M1(p1);
     }
     public static C1 FromObject(object obj)
@@ -157,14 +157,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Date>]
     public static {{typeExpression}} get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Date>] {{typeExpression}} value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.P1 = value;
     }
     public static C1 FromObject(object obj)

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemDateTimeReturnType.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemDateTimeReturnType.cs
@@ -94,7 +94,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Date>]
     public static global::System.{{typeName}} M1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.M1();
     }
     public static C1 FromObject(object obj)

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemNumericParameterType.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemNumericParameterType.cs
@@ -179,7 +179,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Void>]
     public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Number>] {{typeExpression}} arg1)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.M1(arg1);
     }
     public static C1 FromObject(object obj)
@@ -254,14 +254,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Number>]
     public static {{typeExpression}} get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Number>] {{typeExpression}} value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.P1 = value;
     }
     public static C1 FromObject(object obj)

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemStringParameterType.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemStringParameterType.cs
@@ -97,7 +97,7 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.Void>]
     public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.String>] string p1)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.M1(p1);
     }
     public static C1 FromObject(object obj)
@@ -161,14 +161,14 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.String>]
     public static {{typeExpression}} get_P1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.P1;
     }
     [JSExport]
     [return: JSMarshalAs<JSType.Void>]
     public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.String>] {{typeExpression}} value)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         typed_instance.P1 = value;
     }
     public static C1 FromObject(object obj)

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemStringReturnType.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemStringReturnType.cs
@@ -61,8 +61,9 @@ public partial class C1Interop
             using System;
             namespace N1;
             [TSExport]
-            public static class C1
+            public class C1
             {
+                private C1() {}
                 public string M1()
                 {
                     return 1;
@@ -93,8 +94,16 @@ public partial class C1Interop
     [return: JSMarshalAs<JSType.String>]
     public static string M1([JSMarshalAs<JSType.Any>] object instance)
     {
-        C1 typed_instance = (C1)instance;
+        C1 typed_instance = C1Interop.FromObject(instance);
         return typed_instance.M1();
+    }
+    public static C1 FromObject(object obj)
+    {
+        return obj switch
+        {
+            C1 instance => instance,
+            _ => throw new ArgumentException($"Invalid object type {obj?.GetType().ToString() ?? "null"}", nameof(obj)),
+        };
     }
 }
 

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemTaskParameterType.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemTaskParameterType.cs
@@ -320,7 +320,7 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Void>]
             public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Promise<JSType.Void>>] Task? p1)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 typed_instance.M1(p1);
             }
             public static C1 FromObject(object obj)
@@ -383,14 +383,14 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Promise<JSType.Void>>]
             public static Task get_P1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return typed_instance.P1;
             }
             [JSExport]
             [return: JSMarshalAs<JSType.Void>]
             public static void set_P1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Promise<JSType.Void>>] Task value)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 typed_instance.P1 = value;
             }
             public static C1 FromObject(object obj)

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemTaskReturnType.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemTaskReturnType.cs
@@ -202,7 +202,7 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Promise<JSType.Any>>]
             public static Task<object> M1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return typed_instance.M1().ContinueWith(t => (object)t.Result, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
             }
             public static C1 FromObject(object obj)
@@ -315,7 +315,7 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Promise<JSType.Void>>]
             public static Task M1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return typed_instance.M1();
             }
             public static C1 FromObject(object obj)
@@ -372,7 +372,7 @@ public partial class C1Interop
             [return: JSMarshalAs<JSType.Promise<JSType.Void>>]
             public static Task? M1([JSMarshalAs<JSType.Any>] object instance)
             {
-                C1 typed_instance = (C1)instance;
+                C1 typed_instance = C1Interop.FromObject(instance);
                 return typed_instance.M1();
             }
             public static C1 FromObject(object obj)

--- a/src/TypeShim.Generator.Tests/Parsing/SyntaxTreeParsingTests_OptionalEnumParameters.cs
+++ b/src/TypeShim.Generator.Tests/Parsing/SyntaxTreeParsingTests_OptionalEnumParameters.cs
@@ -29,7 +29,7 @@ internal class SyntaxTreeParsingTests_OptionalEnumParameters
         ClassInfo classInfo = new ClassInfoBuilder(exportedSymbols.Single(s => s.TypeKind == TypeKind.Class), typeCache).Build();
 
         MethodInfo method = classInfo.Methods.Single();
-        return method.Parameters.Single(p => !p.IsInjectedInstanceParameter && p.Name == parameterName);
+        return method.Parameters.Single(p => p.Name == parameterName);
     }
 
     [Test]

--- a/src/TypeShim.Generator.Tests/Parsing/SyntaxTreeParsingTests_OptionalParameters.cs
+++ b/src/TypeShim.Generator.Tests/Parsing/SyntaxTreeParsingTests_OptionalParameters.cs
@@ -30,7 +30,7 @@ internal class SyntaxTreeParsingTests_OptionalParameters
         ClassInfo classInfo = new ClassInfoBuilder(exportedClasses[0], typeCache).Build();
 
         MethodInfo method = classInfo.Methods.Single();
-        return method.Parameters.Single(p => !p.IsInjectedInstanceParameter && p.Name == parameterName);
+        return method.Parameters.Single(p => p.Name == parameterName);
     }
 
     [Test]

--- a/src/TypeShim.Generator/CSharp/CSharpMethodRenderer.cs
+++ b/src/TypeShim.Generator/CSharp/CSharpMethodRenderer.cs
@@ -83,11 +83,11 @@ internal sealed class CSharpMethodRenderer(RenderContext _ctx, CSharpTypeConvers
         marshalAsAttributeRenderer.RenderReturnAttribute(methodInfo.ReturnType.JSTypeSyntax);
         _ctx.AppendLine();
 
-        RenderMethodSignature(methodInfo.Name, methodInfo.ReturnType, methodInfo.Parameters);
+        RenderMethodSignature(methodInfo.Name, methodInfo.ReturnType, methodInfo.GetParametersIncludingInstanceParameter());
         _ctx.AppendLine("{");
         using (_ctx.Indent())
         {
-            foreach (MethodParameterInfo originalParamInfo in methodInfo.Parameters)
+            foreach (MethodParameterInfo originalParamInfo in methodInfo.GetParametersIncludingInstanceParameter())
             {
                 _conversionRenderer.RenderParameterTypeConversion(originalParamInfo);
             }
@@ -108,8 +108,7 @@ internal sealed class CSharpMethodRenderer(RenderContext _ctx, CSharpTypeConvers
             }
             else
             {
-                _ctx.Append(_ctx.LocalScope.GetAccessorExpression(methodInfo.Parameters.First(p => p.IsInjectedInstanceParameter)));
-                parameters = [.. methodInfo.Parameters.Skip(1)];
+                _ctx.Append(_ctx.LocalScope.GetAccessorExpression(methodInfo.InstanceParameter!));
             }
 
             _ctx.Append('.').Append(methodInfo.Name).Append('(');
@@ -132,17 +131,17 @@ internal sealed class CSharpMethodRenderer(RenderContext _ctx, CSharpTypeConvers
         marshalAsAttributeRenderer.RenderReturnAttribute(methodInfo.ReturnType.JSTypeSyntax);
         _ctx.AppendLine();
 
-        RenderMethodSignature(methodInfo.Name, methodInfo.ReturnType, methodInfo.Parameters);
+        RenderMethodSignature(methodInfo.Name, methodInfo.ReturnType, methodInfo.GetParametersIncludingInstanceParameter());
         _ctx.AppendLine("{");
 
         using (_ctx.Indent())
         {
-            foreach (MethodParameterInfo originalParamInfo in methodInfo.Parameters)
+            foreach (MethodParameterInfo originalParamInfo in methodInfo.GetParametersIncludingInstanceParameter())
             {
                 _conversionRenderer.RenderParameterTypeConversion(originalParamInfo);
             }
 
-            string accessedObject = methodInfo.IsStatic ? _ctx.Class.Name : _ctx.LocalScope.GetAccessorExpression(methodInfo.Parameters.ElementAt(0));
+            string accessedObject = methodInfo.IsStatic ? _ctx.Class.Name : _ctx.LocalScope.GetAccessorExpression(methodInfo.InstanceParameter!);
             DeferredExpressionRenderer untypedValueExpressionRenderer = DeferredExpressionRenderer.FromUnary(() => _ctx.Append(accessedObject).Append('.').Append(propertyInfo.Name));
             DeferredExpressionRenderer typedValueExpressionRenderer = _conversionRenderer.RenderReturnTypeConversion(methodInfo.ReturnType, untypedValueExpressionRenderer);
             if (methodInfo.ReturnType.ManagedType != KnownManagedType.Void) // getter
@@ -153,7 +152,7 @@ internal sealed class CSharpMethodRenderer(RenderContext _ctx, CSharpTypeConvers
             }
             else // setter
             {
-                string valueVarName = _ctx.LocalScope.GetAccessorExpression(methodInfo.Parameters.First(p => !p.IsInjectedInstanceParameter)); // TODO: get rid of IsInjectedInstanceParameter
+                string valueVarName = _ctx.LocalScope.GetAccessorExpression(methodInfo.Parameters.First());
                 typedValueExpressionRenderer.Render();
                 _ctx.Append(" = ").Append(valueVarName).AppendLine(";");                
             }

--- a/src/TypeShim.Generator/CSharp/CSharpTypeConversionRenderer.cs
+++ b/src/TypeShim.Generator/CSharp/CSharpTypeConversionRenderer.cs
@@ -16,7 +16,7 @@ internal sealed class CSharpTypeConversionRenderer(RenderContext _ctx)
         string varName = _ctx.LocalScope.GetAccessorExpression(parameterInfo);
         string newVarName = $"typed_{_ctx.LocalScope.GetAccessorExpression(parameterInfo)}";
 
-        DeferredExpressionRenderer convertedValueAccessor = RenderTypeDownConversion(parameterInfo.Type, varName, DeferredExpressionRenderer.FromUnary(() => _ctx.Append(varName)), parameterInfo.IsInjectedInstanceParameter);
+        DeferredExpressionRenderer convertedValueAccessor = RenderTypeDownConversion(parameterInfo.Type, varName, DeferredExpressionRenderer.FromUnary(() => _ctx.Append(varName)));
         _ctx.Append(parameterInfo.Type.CSharpTypeSyntax.ToString()).Append(' ').Append(newVarName).Append(" = ");
         convertedValueAccessor.Render();
         _ctx.AppendLine(";");
@@ -25,10 +25,10 @@ internal sealed class CSharpTypeConversionRenderer(RenderContext _ctx)
 
     internal DeferredExpressionRenderer RenderVarTypeConversion(InteropTypeInfo typeInfo, string varName, DeferredExpressionRenderer valueExpressionRenderer)
     {
-        return RenderTypeDownConversion(typeInfo, varName, valueExpressionRenderer, false);
+        return RenderTypeDownConversion(typeInfo, varName, valueExpressionRenderer);
     }
 
-    private DeferredExpressionRenderer RenderTypeDownConversion(InteropTypeInfo typeInfo, string accessorName, DeferredExpressionRenderer accessorExpressionRenderer, bool isInstanceParameter)
+    private DeferredExpressionRenderer RenderTypeDownConversion(InteropTypeInfo typeInfo, string accessorName, DeferredExpressionRenderer accessorExpressionRenderer)
     {
         if (!typeInfo.RequiresTypeConversion)
             return accessorExpressionRenderer;
@@ -43,7 +43,7 @@ internal sealed class CSharpTypeConversionRenderer(RenderContext _ctx)
         }
         else
         {
-            return DeferredExpressionRenderer.FromUnary(() => RenderInlineTypeDownConversion(typeInfo, accessorName, accessorExpressionRenderer, forceCovariantConversion: isInstanceParameter));
+            return DeferredExpressionRenderer.FromUnary(() => RenderInlineTypeDownConversion(typeInfo, accessorName, accessorExpressionRenderer));
         }
     }
 
@@ -85,14 +85,10 @@ internal sealed class CSharpTypeConversionRenderer(RenderContext _ctx)
         }
     }
 
-    private void RenderInlineTypeDownConversion(InteropTypeInfo typeInfo, string accessorName, DeferredExpressionRenderer accessorExpressionRenderer, bool forceCovariantConversion = false)
+    private void RenderInlineTypeDownConversion(InteropTypeInfo typeInfo, string accessorName, DeferredExpressionRenderer accessorExpressionRenderer)
     {
         ArgumentNullException.ThrowIfNull(typeInfo, nameof(typeInfo));
-        if (forceCovariantConversion)
-        {
-            RenderInlineCovariantTypeDownConversion(typeInfo, accessorExpressionRenderer);
-        }
-        else if (typeInfo.IsArrayType)
+        if (typeInfo.IsArrayType)
         {
             RenderInlineArrayTypeDownConversion(typeInfo, accessorExpressionRenderer);
         }

--- a/src/TypeShim.Generator/LocalScope.cs
+++ b/src/TypeShim.Generator/LocalScope.cs
@@ -9,7 +9,7 @@ internal sealed class LocalScope
     
     internal LocalScope(MethodInfo methodInfo)
     {
-        paramNameDict = methodInfo.Parameters.ToDictionary(c => c, c => c.Name);
+        paramNameDict = methodInfo.GetParametersIncludingInstanceParameter().ToDictionary(c => c, c => c.Name);
     }
 
     internal LocalScope(ConstructorInfo constructorInfo)

--- a/src/TypeShim.Generator/Parsing/ConstructorInfoBuilder.cs
+++ b/src/TypeShim.Generator/Parsing/ConstructorInfoBuilder.cs
@@ -14,7 +14,6 @@ internal sealed class ConstructorInfoBuilder(INamedTypeSymbol classSymbol, IMeth
         MethodParameterInfo? initializersObjectParameter = initializerProperties.Length == 0 ? null : new()
         {
             Name = "initializer",
-            IsInjectedInstanceParameter = false,
             Type = InteropTypeInfo.JSObjectTypeInfo
         };
 

--- a/src/TypeShim.Generator/Parsing/MethodInfo.cs
+++ b/src/TypeShim.Generator/Parsing/MethodInfo.cs
@@ -7,24 +7,22 @@ internal sealed class MethodInfo
 {
     internal required bool IsStatic { get; init; }
     internal required string Name { get; init; }
+    internal required MethodParameterInfo? InstanceParameter { get; init; }
     internal required IReadOnlyCollection<MethodParameterInfo> Parameters { get; init; }
     internal required InteropTypeInfo ReturnType { get; init; }
     internal required CommentInfo? Comment { get; init; }
 
-    public MethodInfo WithoutInstanceParameter()
+    internal IReadOnlyCollection<MethodParameterInfo> GetParametersIncludingInstanceParameter()
     {
-        return new MethodInfo
+        if (InstanceParameter is MethodParameterInfo instanceParameter)
         {
-            IsStatic = this.IsStatic,
-            Name = this.Name,
-            Parameters = [.. this.Parameters.Where(p => !p.IsInjectedInstanceParameter)],
-            ReturnType = this.ReturnType,
-            Comment = this.Comment,
-        };
+            return [instanceParameter, .. Parameters];
+        }
+        return Parameters;
     }
 
     internal bool MatchesDisposeSignature()
     {
-        return Name == "Dispose" && !Parameters.Any(p => !p.IsInjectedInstanceParameter) && ReturnType.ManagedType == KnownManagedType.Void;
+        return Name == "Dispose" && Parameters.Count == 0 && ReturnType.ManagedType == KnownManagedType.Void;
     }
 }

--- a/src/TypeShim.Generator/Parsing/MethodInfoBuilder.cs
+++ b/src/TypeShim.Generator/Parsing/MethodInfoBuilder.cs
@@ -19,6 +19,7 @@ internal sealed class MethodInfoBuilder(INamedTypeSymbol classSymbol, IMethodSym
         }
 
         bool isJSExport = SymbolFacts.HasJSExportAttribute(memberMethod);
+        MethodParameterInfo? instanceParameter = parameterInfoBuilder.BuildInstanceParameter();
         IReadOnlyCollection<MethodParameterInfo> parameters = [.. parameterInfoBuilder.Build()];
         InteropTypeInfo returnType = typeInfoBuilder.Build();
 
@@ -41,6 +42,7 @@ internal sealed class MethodInfoBuilder(INamedTypeSymbol classSymbol, IMethodSym
         {
             IsStatic = memberMethod.IsStatic,
             Name = memberMethod.Name,
+            InstanceParameter = instanceParameter,
             Parameters = parameters,
             ReturnType = returnType,
             Comment = new CommentInfoBuilder(memberMethod).Build(),

--- a/src/TypeShim.Generator/Parsing/MethodParameterInfo.cs
+++ b/src/TypeShim.Generator/Parsing/MethodParameterInfo.cs
@@ -3,6 +3,5 @@
 internal class MethodParameterInfo
 {
     internal required string Name { get; init; }
-    internal required bool IsInjectedInstanceParameter { get; init; }
     internal required InteropTypeInfo Type { get; init; }
 }

--- a/src/TypeShim.Generator/Parsing/MethodParameterInfoBuilder.cs
+++ b/src/TypeShim.Generator/Parsing/MethodParameterInfoBuilder.cs
@@ -3,24 +3,27 @@ using TypeShim.Shared;
 
 internal class MethodParameterInfoBuilder(INamedTypeSymbol classSymbol, IMethodSymbol memberMethod, InteropTypeInfoCache typeInfoCache)
 {
-    internal IEnumerable<MethodParameterInfo> Build()
+    internal MethodParameterInfo? BuildInstanceParameter()
     {
         if (!memberMethod.IsStatic && memberMethod.MethodKind is not MethodKind.Constructor)
         {
-            yield return new MethodParameterInfo
+            return new MethodParameterInfo
             {
                 Name = "instance",
-                IsInjectedInstanceParameter = true,
                 Type = new InteropTypeInfoBuilder(classSymbol, typeInfoCache).Build()
             };
         }
 
+        return null;
+    }
+
+    internal IEnumerable<MethodParameterInfo> Build()
+    {
         foreach (IParameterSymbol parameterSymbol in memberMethod.Parameters)
         {
             yield return new MethodParameterInfo
             {
                 Name = parameterSymbol.Name,
-                IsInjectedInstanceParameter = false,
                 Type = new InteropTypeInfoBuilder(parameterSymbol.Type, typeInfoCache).Build()
             };
         }

--- a/src/TypeShim.Generator/Typescript/TypeScriptMethodRenderer.cs
+++ b/src/TypeShim.Generator/Typescript/TypeScriptMethodRenderer.cs
@@ -53,7 +53,7 @@ internal sealed class TypeScriptMethodRenderer(RenderContext ctx)
             using (ctx.Indent())
             {
                 ctx.Append("super(");
-                RenderInteropInvocation(constructorInfo.Name, constructorInfo.Parameters, constructorInfo.InitializerObject);
+                RenderInteropInvocation(constructorInfo.Name, constructorInfo.Parameters, instanceParameter: null, constructorInfo.InitializerObject);
                 ctx.AppendLine(");");
             }
             ctx.AppendLine("}");
@@ -63,7 +63,7 @@ internal sealed class TypeScriptMethodRenderer(RenderContext ctx)
     internal void RenderProxyMethod(MethodInfo methodInfo)
     {
         TypeScriptJSDocRenderer.RenderJSDoc(ctx, methodInfo.Comment);
-        RenderProxyMethodSignature(methodInfo.WithoutInstanceParameter());
+        RenderProxyMethodSignature(methodInfo);
         RenderMethodBody(methodInfo);
 
         void RenderProxyMethodSignature(MethodInfo methodInfo)
@@ -83,13 +83,13 @@ internal sealed class TypeScriptMethodRenderer(RenderContext ctx)
     {
         TypeScriptJSDocRenderer.RenderJSDoc(ctx, propertyInfo.Comment);
         MethodInfo getterInfo = propertyInfo.GetMethod;
-        RenderProxyPropertyGetterSignature(getterInfo.WithoutInstanceParameter());
+        RenderProxyPropertyGetterSignature(getterInfo);
         RenderMethodBody(getterInfo);
 
         if (propertyInfo.SetMethod is MethodInfo setterInfo)
         {
             ctx.AppendLine();
-            RenderProxyPropertySetterSignature(setterInfo.WithoutInstanceParameter());
+            RenderProxyPropertySetterSignature(setterInfo);
             RenderMethodBody(setterInfo);
         }
 
@@ -151,7 +151,7 @@ internal sealed class TypeScriptMethodRenderer(RenderContext ctx)
             if (requiresProxyConversion || requiresCharConversion)
             {
                 ctx.Append("const res = ");
-                RenderInteropInvocation(methodInfo.Name, methodInfo.Parameters);
+                RenderInteropInvocation(methodInfo.Name, methodInfo.Parameters, methodInfo.InstanceParameter);
                 ctx.AppendLine(";");
 
                 ctx.Append($"return ");
@@ -161,7 +161,7 @@ internal sealed class TypeScriptMethodRenderer(RenderContext ctx)
             else
             {
                 ctx.Append(methodInfo.ReturnType.ManagedType == KnownManagedType.Void ? string.Empty : "return ");
-                RenderInteropInvocation(methodInfo.Name, methodInfo.Parameters);
+                RenderInteropInvocation(methodInfo.Name, methodInfo.Parameters, methodInfo.InstanceParameter);
             }
             ctx.AppendLine(";");
 
@@ -369,27 +369,28 @@ internal sealed class TypeScriptMethodRenderer(RenderContext ctx)
         }
     }
 
-    private void RenderInteropInvocation(string methodName, IEnumerable<MethodParameterInfo> methodParameters, MethodParameterInfo? initializerObject = null)
+    private void RenderInteropInvocation(string methodName, IEnumerable<MethodParameterInfo> methodParameters, MethodParameterInfo? instanceParameter = null, MethodParameterInfo? initializerObject = null)
     {
         ctx.Append("TypeShimConfig.exports.");
         RenderInteropMethodAccessor(methodName);
         ctx.Append("(");
-        RenderMethodInvocationParameters("this.instance");
+        RenderMethodInvocationParameters();
         ctx.Append(")");
 
-        void RenderMethodInvocationParameters(string instanceParameterExpression)
+        void RenderMethodInvocationParameters()
         {
             bool isFirst = true;
+            if (instanceParameter != null)
+            {
+                ctx.Append("this.instance");
+                isFirst = false;
+            }
             foreach (MethodParameterInfo parameter in methodParameters)
             {
                 if (!isFirst) ctx.Append(", ");
 
                 void renderParameter() => ctx.Append(parameter.Name);
-                if (parameter.IsInjectedInstanceParameter)
-                {
-                    ctx.Append(instanceParameterExpression);
-                }
-                else if (ctx.SymbolMap.IsConversionRequiringClassOrDelegate(parameter.Type) || RequiresCharConversion(parameter.Type))
+                if (ctx.SymbolMap.IsConversionRequiringClassOrDelegate(parameter.Type) || RequiresCharConversion(parameter.Type))
                 {
                     RenderInlineHandleExtraction(parameter.Type, renderParameter);
                 }

--- a/src/TypeShim.Generator/Typescript/TypescriptAssemblyExportsRenderer.cs
+++ b/src/TypeShim.Generator/Typescript/TypescriptAssemblyExportsRenderer.cs
@@ -46,25 +46,30 @@ internal sealed class TypescriptAssemblyExportsRenderer(
     {
         if (classInfo.Constructor is ConstructorInfo constructorInfo)
         {
-            RenderInteropMethodSignature(constructorInfo.Name, constructorInfo.GetParametersIncludingInitializerObject(), constructorInfo.Type);
+            RenderInteropMethodSignature(constructorInfo.Name, instanceParameter: null, constructorInfo.GetParametersIncludingInitializerObject(), constructorInfo.Type);
         }
         foreach (MethodInfo methodInfo in GetAllMethods(classInfo))
         {
-            RenderInteropMethodSignature(methodInfo.Name, methodInfo.Parameters, methodInfo.ReturnType);
+            RenderInteropMethodSignature(methodInfo.Name, methodInfo.InstanceParameter, methodInfo.Parameters, methodInfo.ReturnType);
         }
     }
 
-    private void RenderInteropMethodSignature(string name, IEnumerable<MethodParameterInfo> parameters, InteropTypeInfo returnType)
+    private void RenderInteropMethodSignature(string name, MethodParameterInfo? instanceParameter, IEnumerable<MethodParameterInfo> parameters, InteropTypeInfo returnType)
     {
         ctx.Append(name).Append('(');
         bool isFirst = true;
+        if (instanceParameter != null)
+        {
+            ctx.Append(instanceParameter.Name).Append(": ");
+            TypeScriptSymbolNameRenderer.Render(instanceParameter.Type, ctx, TypeShimSymbolType.Proxy, interop: true);
+            isFirst = false;
+        }
         foreach (MethodParameterInfo parameterInfo in parameters)
         {
             if (!isFirst) ctx.Append(", ");
 
             ctx.Append(parameterInfo.Name).Append(": ");
-            // TODO: remove IsInjectedInstanceParameter property and split into separate methodInfo property
-            TypeShimSymbolType symbolType = parameterInfo.IsInjectedInstanceParameter || parameterInfo.Type.IsDelegateType() ? TypeShimSymbolType.Proxy : TypeShimSymbolType.ProxyInitializerUnion;
+            TypeShimSymbolType symbolType = parameterInfo.Type.IsDelegateType() ? TypeShimSymbolType.Proxy : TypeShimSymbolType.ProxyInitializerUnion;
             TypeScriptSymbolNameRenderer.Render(parameterInfo.Type, ctx, symbolType, interop: true);
             isFirst = false;
         }


### PR DESCRIPTION
Make the instance param an explicit property rather than an implicit entry in the params list.

Removes a shortcut for instance parameter type conversion to reuse the `FromObject` mapper, functionally equivalent, simpler code but high test baseline churn.