### PR TITLE
feat: Enum related diagnostics 

### DIFF
--- a/src/TypeShim.Analyzers.Tests/EnumDiagnosticsTests.cs
+++ b/src/TypeShim.Analyzers.Tests/EnumDiagnosticsTests.cs
@@ -8,6 +8,7 @@ internal class EnumDiagnosticsTests
     private static readonly string NonExportedTypeId = TypeShimDiagnostics.NonExportedTypeInInteropApiRule.Id;
     private static readonly string UnsupportedTypeId = TypeShimDiagnostics.UnsupportedTypeRule.Id;
     private static readonly string ConstScopeId = TypeShimDiagnostics.UnresolvableDefaultConstRule.Id;
+    private static readonly string MemberOutOfRangeId = TypeShimDiagnostics.EnumMemberOutOfSafeRangeRule.Id;
 
     [Test]
     public async Task UnannotatedEnumParameter_IsFlaggedAsNonExported()
@@ -195,5 +196,172 @@ internal class EnumDiagnosticsTests
 
         var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(source);
         Assert.That(diagnostics.Any(d => d.Id == UnsupportedTypeId), Is.True);
+    }
+
+    [Test]
+    public async Task ULongUnderlyingEnum_IsFlaggedAsUnsupported_NamingUnderlyingType()
+    {
+        // ulong is unsigned and cannot cross the .NET-JS boundary; the message must name the offending
+        // underlying type so the fix (switch to a signed type) is obvious.
+        string source = """
+            using System;
+            using TypeShim;
+
+            [TSExport]
+            public enum Priority : ulong { Low, Medium, High }
+            """;
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(source);
+        Assert.That(diagnostics.Any(d => d.Id == UnsupportedTypeId && d.GetMessage().Contains("ulong")), Is.True);
+    }
+
+    [TestCase("ulong")]
+    [TestCase("uint")]
+    [TestCase("ushort")]
+    [TestCase("sbyte")]
+    public async Task UnsupportedUnderlyingEnum_IsFlagged_NamingUnderlyingType(string underlying)
+    {
+        string source = """
+            using System;
+            using TypeShim;
+
+            [TSExport]
+            public enum Priority : {{underlying}} { Low, Medium, High }
+            """.Replace("{{underlying}}", underlying);
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(source);
+        Assert.That(diagnostics.Any(d => d.Id == UnsupportedTypeId && d.GetMessage().Contains(underlying)), Is.True);
+    }
+
+    [TestCase("byte")]
+    [TestCase("short")]
+    [TestCase("int")]
+    [TestCase("long")]
+    public async Task SupportedUnderlyingEnum_IsNotFlaggedAsUnsupported(string underlying)
+    {
+        string source = """
+            using System;
+            using TypeShim;
+
+            [TSExport]
+            public enum Priority : {{underlying}} { Low, Medium, High }
+
+            [TSExport]
+            public class C1
+            {
+                public void M(Priority p) { }
+            }
+            """.Replace("{{underlying}}", underlying);
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(source);
+        Assert.That(diagnostics.Any(d => d.Id == UnsupportedTypeId), Is.False);
+    }
+
+    [Test]
+    public async Task UnsupportedUnderlyingEnum_DoesNotAlsoReportMemberOutOfRange()
+    {
+        // The underlying-type error short-circuits member inspection: the members may not even fit in Int64.
+        string source = """
+            using System;
+            using TypeShim;
+
+            [TSExport]
+            public enum Priority : ulong { Low = 0, High = 18446744073709551615 }
+            """;
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(source);
+        Assert.That(diagnostics.Any(d => d.Id == MemberOutOfRangeId), Is.False);
+    }
+
+    [Test]
+    public async Task LongEnumMemberAboveSafeRange_IsFlaggedAsOutOfRange()
+    {
+        // 9007199254740992 == 2^53, the first value above the JS-safe range.
+        string source = """
+            using System;
+            using TypeShim;
+
+            [TSExport]
+            public enum Big : long { Zero = 0, Max = 9007199254740992 }
+            """;
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(source);
+        Assert.That(diagnostics.Any(d => d.Id == MemberOutOfRangeId && d.GetMessage().Contains("Max")), Is.True);
+    }
+
+    [Test]
+    public async Task LongEnumMemberBelowSafeRange_IsFlaggedAsOutOfRange()
+    {
+        string source = """
+            using System;
+            using TypeShim;
+
+            [TSExport]
+            public enum Big : long { Zero = 0, Min = -9007199254740992 }
+            """;
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(source);
+        Assert.That(diagnostics.Any(d => d.Id == MemberOutOfRangeId && d.GetMessage().Contains("Min")), Is.True);
+    }
+
+    [Test]
+    public async Task LongEnumMemberAtSafeBoundary_IsNotFlagged()
+    {
+        // 9007199254740991 == 2^53 - 1, the largest exactly-representable JS integer; the boundary is inclusive.
+        string source = """
+            using System;
+            using TypeShim;
+
+            [TSExport]
+            public enum Big : long { Small = 0, Max = 9007199254740991, Min = -9007199254740991 }
+            """;
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(source);
+        Assert.That(diagnostics.Any(d => d.Id == MemberOutOfRangeId), Is.False);
+    }
+
+    [Test]
+    public async Task MultipleOutOfRangeEnumMembers_AreEachFlagged()
+    {
+        string source = """
+            using System;
+            using TypeShim;
+
+            [TSExport]
+            public enum Big : long { Zero = 0, TooBig = 9007199254740992, TooSmall = -9007199254740992 }
+            """;
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(source);
+        Assert.That(diagnostics.Count(d => d.Id == MemberOutOfRangeId), Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task InRangeEnumMembers_AreNotFlagged()
+    {
+        string source = """
+            using System;
+            using TypeShim;
+
+            [TSExport]
+            public enum Priority { Low, Medium, High }
+            """;
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(source);
+        Assert.That(diagnostics.Any(d => d.Id == MemberOutOfRangeId), Is.False);
+    }
+
+    [Test]
+    public async Task NonExportedEnum_WithOutOfRangeMember_IsNotFlaggedForRange()
+    {
+        // Member-range validation only applies to [TSExport] enums that are actually emitted.
+        string source = """
+            using System;
+            using TypeShim;
+
+            public enum Big : long { Zero = 0, Max = 9007199254740992 }
+            """;
+
+        var diagnostics = await AnalyzerTestHelper.GetDiagnosticsAsync(source);
+        Assert.That(diagnostics.Any(d => d.Id == MemberOutOfRangeId), Is.False);
     }
 }

--- a/src/TypeShim.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/TypeShim.Analyzers/AnalyzerReleases.Unshipped.md
@@ -9,3 +9,4 @@ TSHIM010 | Usage | Error | TypeShimAnalyzer
 TSHIM013 | Usage | Error | TypeShimAnalyzer
 TSHIM014 | Usage | Error | TypeShimAnalyzer
 TSHIM015 | Usage | Error | TypeShimAnalyzer
+TSHIM016 | TypeChecking | Error | TypeShimAnalyzer

--- a/src/TypeShim.Analyzers/TypeShimAnalyzer.cs
+++ b/src/TypeShim.Analyzers/TypeShimAnalyzer.cs
@@ -26,7 +26,8 @@ internal sealed class TypeShimAnalyzer : DiagnosticAnalyzer
         TypeShimDiagnostics.MixedExportRule,
         TypeShimDiagnostics.UnresolvableDefaultConstRule,
         TypeShimDiagnostics.NoOptionalMemoryViewRule,
-        TypeShimDiagnostics.NoOptionalCtorParamWithRequiredInitializerRule
+        TypeShimDiagnostics.NoOptionalCtorParamWithRequiredInitializerRule,
+        TypeShimDiagnostics.EnumMemberOutOfSafeRangeRule
     ];
 
     public override void Initialize(AnalysisContext context)
@@ -34,6 +35,7 @@ internal sealed class TypeShimAnalyzer : DiagnosticAnalyzer
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterSymbolAction(AnalyzeClass, SymbolKind.NamedType);
+        context.RegisterSymbolAction(AnalyzeEnum, SymbolKind.NamedType);
         context.RegisterSymbolAction(AnalyzeMethodForMixedExport, SymbolKind.Method);
         context.RegisterSyntaxNodeAction(CheckOptionalParameterDefault, SyntaxKind.Parameter);
     }
@@ -247,6 +249,57 @@ internal sealed class TypeShimAnalyzer : DiagnosticAnalyzer
         {
             string fieldName = field.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
             context.ReportDiagnostic(Diagnostic.Create(TypeShimDiagnostics.NoRequiredFieldsRule, LocationFinder.GetDefaultLocation(field), fieldName));
+        }
+    }
+
+    // JS numbers represent integers exactly only within +/-(2^53 - 1).
+    private const long MaxSafeInteger = 9007199254740991;
+
+    private static void AnalyzeEnum(SymbolAnalysisContext context)
+    {
+        if (context.Symbol is not INamedTypeSymbol type || type.TypeKind != TypeKind.Enum)
+            return;
+
+        if (!SymbolFacts.HasTSExportAttribute(type))
+            return;
+
+        // An unsupported underlying type makes the whole enum unrepresentable, and its member values may
+        // not even fit in Int64, so report that and stop before inspecting members.
+        if (!UnderlyingTypeIsSupported(context, type))
+            return;
+
+        CheckEnumMemberRanges(context, type);
+    }
+
+    private static bool UnderlyingTypeIsSupported(SymbolAnalysisContext context, INamedTypeSymbol enumType)
+    {
+        try
+        {
+            _ = new InteropTypeInfoBuilder(enumType, new InteropTypeInfoCache()).Build();
+            return true;
+        }
+        catch (NotSupportedTypeException)
+        {
+            string underlying = enumType.EnumUnderlyingType?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat) ?? "int";
+            string display = $"{enumType.Name} : {underlying}";
+            context.ReportDiagnostic(Diagnostic.Create(TypeShimDiagnostics.UnsupportedTypeRule, LocationFinder.GetDefaultLocation(enumType), display));
+            return false;
+        }
+    }
+
+    private static void CheckEnumMemberRanges(SymbolAnalysisContext context, INamedTypeSymbol enumType)
+    {
+        foreach (IFieldSymbol field in enumType.GetMembers().OfType<IFieldSymbol>())
+        {
+            if (!field.IsConst || field.ConstantValue is null)
+                continue; // skip the synthesized value__ instance field
+
+            long value = Convert.ToInt64(field.ConstantValue);
+            if (value > MaxSafeInteger || value < -MaxSafeInteger)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    TypeShimDiagnostics.EnumMemberOutOfSafeRangeRule, LocationFinder.GetDefaultLocation(field), field.Name, value));
+            }
         }
     }
 

--- a/src/TypeShim.Analyzers/TypeShimDiagnostics.cs
+++ b/src/TypeShim.Analyzers/TypeShimDiagnostics.cs
@@ -114,4 +114,13 @@ internal static class TypeShimDiagnostics
         isEnabledByDefault: true,
         description: "A constructor's trailing initializer object can only be optional when every settable/init property is nullable, so it cannot follow an optional parameter otherwise.");
 
+    internal static readonly DiagnosticDescriptor EnumMemberOutOfSafeRangeRule = new(
+        id: "TSHIM016",
+        title: "Enum member value is outside the JS number range",
+        messageFormat: "Enum member '{0}' has value {1}, which is outside the JS number range (+/-2^53-1)",
+        category: "TypeChecking",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "JS numbers represent integers exactly only within +/-(2^53-1); enum members outside that range cannot cross the .NET-JS boundary.");
+
 }


### PR DESCRIPTION
add diagnostics covering last items of #116, specifically out of range values + clear non-exported type (enum name + violating underlying type)