### PR TITLE
feat: Block codegen on syntax errors

### DIFF
--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_Delegates.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_Delegates.cs
@@ -648,7 +648,7 @@ public partial class C1Interop
             [TSExport]
             public class C1
             {
-                public Func<int, MyClass?> M1() {}
+                public Func<int, MyClass?> M1() { return default!; }
             }
         """);
         SymbolExtractor symbolExtractor = new([CSharpFileInfo.Create(syntaxTree), CSharpFileInfo.Create(userClass)], TestFixture.TargetingPackRefDir);
@@ -718,7 +718,7 @@ public partial class C1Interop
             [TSExport]
             public class C1
             {
-                public Func<MyClass?> M1() {}
+                public Func<MyClass?> M1() { return default!; }
             }
         """);
         SymbolExtractor symbolExtractor = new([CSharpFileInfo.Create(syntaxTree), CSharpFileInfo.Create(userClass)], TestFixture.TargetingPackRefDir);

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_ParameterAttributes.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_ParameterAttributes.cs
@@ -168,4 +168,38 @@ public partial class C1Interop
 
 """);
     }
+
+    [Test]
+    public void UnknownParameterAttribute_DoesNotAffectInterop()
+    {
+        string output = Render("    public void M1(string value, [UnknownParameterAttribute] string? expr = null) {}");
+
+        AssertEx.EqualOrDiff(output, """
+#nullable enable
+// TypeShim generated TypeScript interop definitions
+using System;
+using System.Runtime.InteropServices.JavaScript;
+using System.Threading.Tasks;
+namespace N1;
+public partial class C1Interop
+{
+    [JSExport]
+    [return: JSMarshalAs<JSType.Void>]
+    public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.String>] string value, [JSMarshalAs<JSType.String>] string? expr)
+    {
+        C1 typed_instance = C1Interop.FromObject(instance);
+        typed_instance.M1(value, expr);
+    }
+    public static C1 FromObject(object obj)
+    {
+        return obj switch
+        {
+            C1 instance => instance,
+            _ => throw new ArgumentException($"Invalid object type {obj?.GetType().ToString() ?? "null"}", nameof(obj)),
+        };
+    }
+}
+
+""");
+    }
 }

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemDateTimeReturnType.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemDateTimeReturnType.cs
@@ -20,6 +20,7 @@ internal class CSharpInteropClassRendererTests_SystemDateTimeReturnType
             {
                 public static {{typeName}} M1()
                 {
+                    return default!;
                 }
             }
         """.Replace("{{typeName}}", typeName));
@@ -67,6 +68,7 @@ public partial class C1Interop
                 private C1() {}
                 public {{typeName}} M1()
                 {
+                    return default!;
                 }
             }
         """.Replace("{{typeName}}", typeName));

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemStringParameterType.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemStringParameterType.cs
@@ -125,7 +125,7 @@ public partial class C1Interop
             [TSExport]
             public class C1
             {
-                public {{typeName}} P1 { get; set }
+                public {{typeName}} P1 { get; set; }
             }
         """.Replace("{{typeName}}", typeName));
 

--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemTaskReturnType.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_SystemTaskReturnType.cs
@@ -232,7 +232,7 @@ public partial class C1Interop
                 private C1() {}
                 public static Task<{{typeName}}> M1()
                 {
-                    return Task.FromResult({objectCreation});
+                    return Task.FromResult({{objectCreation}});
                 }
             }
         """.Replace("{{typeName}}", typeName).Replace("{{objectCreation}}", objectCreation));

--- a/src/TypeShim.Generator.Tests/CSharp/JSObjectExtensionsRendererTests_Properties.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/JSObjectExtensionsRendererTests_Properties.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using TypeShim.Generator.CSharp;
 using TypeShim.Generator.Parsing;
@@ -26,7 +26,7 @@ internal class JSObjectExtensionsRendererTests_Properties
             [TSExport]
             public class C1
             {
-                public {{type}} P1 { get; set; }
+                public {{type}} P1 { get => default; set { } }
             }
         """.Replace("{{type}}", csTypeName);
 
@@ -247,7 +247,7 @@ internal class JSObjectExtensionsRendererTests_Properties
             [TSExport]
             public class C1
             {
-                public {{type}} P1 { get; set; }
+                public {{type}} P1 { get => default; set { } }
             }
         """.Replace("{{type}}", csTypeName);
 
@@ -334,7 +334,7 @@ internal class JSObjectExtensionsRendererTests_Properties
             [TSExport]
             public class C1
             {
-                public {{type}} P1 { get; set; }
+                public {{type}} P1 { get => default; set { } }
             }
         """.Replace("{{type}}", exposedTypeName);
 
@@ -407,7 +407,7 @@ internal class JSObjectExtensionsRendererTests_Properties
             [TSExport]
             public class C1
             {
-                public {{type}} P1 { get; set; }
+                public {{type}} P1 { get => default; set { } }
             }
         """.Replace("{{type}}", exposedTypeName);
 

--- a/src/TypeShim.Generator.Tests/Parsing/ExportedSignatureGateTests.cs
+++ b/src/TypeShim.Generator.Tests/Parsing/ExportedSignatureGateTests.cs
@@ -28,7 +28,7 @@ internal class ExportedSignatureGateTests
             }
         """);
 
-        TypeShimException ex = Assert.Throws<TypeShimException>(() => extractor.ExtractAllExportedSymbols());
+        InvalidCodeException ex = Assert.Throws<InvalidCodeException>(() => extractor.ExtractAllExportedSymbols());
         Assert.That(ex!.Message, Does.Contain("CS0708"));
     }
 
@@ -49,7 +49,7 @@ internal class ExportedSignatureGateTests
             }
         """);
 
-        TypeShimException ex = Assert.Throws<TypeShimException>(() => extractor.ExtractAllExportedSymbols());
+        InvalidCodeException ex = Assert.Throws<InvalidCodeException>(() => extractor.ExtractAllExportedSymbols());
         Assert.That(ex!.Message, Does.Contain("invalid code"));
     }
 

--- a/src/TypeShim.Generator.Tests/Parsing/ExportedSignatureGateTests.cs
+++ b/src/TypeShim.Generator.Tests/Parsing/ExportedSignatureGateTests.cs
@@ -1,0 +1,127 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TypeShim.Generator.Parsing;
+using TypeShim.Shared;
+
+namespace TypeShim.Generator.Tests.Parsing;
+
+internal class ExportedSignatureGateTests
+{
+    private static SymbolExtractor Extractor(string source)
+        => new([CSharpFileInfo.Create(CSharpSyntaxTree.ParseText(source))], TestFixture.TargetingPackRefDir);
+
+    [Test]
+    public void ExtractAllExportedSymbols_InstanceMemberInStaticClass_ThrowsWithCs0708()
+    {
+        // CS0708: instance member declared in a static class. Extracts into a valid-looking symbol
+        // but guarantees broken codegen, so the gate must stop the run.
+        SymbolExtractor extractor = Extractor("""
+            using System;
+            namespace N1;
+            [TSExport]
+            public static class C1
+            {
+                public string M1()
+                {
+                    return "x";
+                }
+            }
+        """);
+
+        TypeShimException ex = Assert.Throws<TypeShimException>(() => extractor.ExtractAllExportedSymbols());
+        Assert.That(ex!.Message, Does.Contain("CS0708"));
+    }
+
+    [Test]
+    public void ExtractAllExportedSymbols_StrayBraceInBody_ThrowsSyntaxError()
+    {
+        // A stray brace reparents sibling members out of the class; the syntax gate must catch it
+        // even though the signature span itself is clean.
+        SymbolExtractor extractor = Extractor("""
+            using System;
+            namespace N1;
+            [TSExport]
+            public class C1
+            {
+                private C1() {}
+                public string M1() { return "x"; }}
+                public string M2() { return "y"; }
+            }
+        """);
+
+        TypeShimException ex = Assert.Throws<TypeShimException>(() => extractor.ExtractAllExportedSymbols());
+        Assert.That(ex!.Message, Does.Contain("invalid code"));
+    }
+
+    [Test]
+    public void ExtractAllExportedSymbols_ValidSignatureReferencingNonExportedType_GateDoesNotThrow()
+    {
+        // The parameter type 'Foo' is valid C# but non-exported, so the rewriter strips it and the
+        // signature span reports CS0246. That is a partial-compilation artifact the gate must ignore;
+        // rejection (if any) belongs to the parser downstream, not this gate.
+        SymbolExtractor extractor = Extractor("""
+            using System;
+            namespace N1;
+            public class Foo {}
+            [TSExport]
+            public class C1
+            {
+                private C1() {}
+                public void M1(Foo f) {}
+            }
+        """);
+
+        List<INamedTypeSymbol> exported = [.. extractor.ExtractAllExportedSymbols()];
+        Assert.That(exported.Select(s => s.Name), Does.Contain("C1"));
+    }
+
+    [Test]
+    public void ExtractAllExportedSymbols_RichValidSurface_DoesNotThrow()
+    {
+        SymbolExtractor extractor = Extractor("""
+            using System;
+            using System.Threading.Tasks;
+            namespace N1;
+            [TSExport]
+            public class C1
+            {
+                private C1() {}
+                public DateTime P1 { get; set; }
+                public Task<int> M1(string s, int[] arr, DateTime dt, Func<int, int> f, bool? b)
+                {
+                    return Task.FromResult(1);
+                }
+                public void M2(TimeSpan ts, double d, long l, char c) {}
+            }
+        """);
+
+        List<INamedTypeSymbol> exported = [.. extractor.ExtractAllExportedSymbols()];
+        Assert.That(exported.Select(s => s.Name), Does.Contain("C1"));
+    }
+
+    [Test]
+    public void ExtractAllExportedSymbols_CustomAttributeOnMethod_DoesNotThrow()
+    {
+        // The custom attribute is not in the partial compilation's references, so anchoring the
+        // signature span at the node start would surface a spurious CS0246. Anchoring at the return
+        // type excludes attributes, so the gate must not throw here.
+        SymbolExtractor extractor = Extractor("""
+            using System;
+            namespace N1;
+            public sealed class MyCustomAttribute : Attribute {}
+            [TSExport]
+            public class C1
+            {
+                private C1() {}
+                [MyCustom]
+                public string M1()
+                {
+                    return "x";
+                }
+            }
+        """);
+
+        List<INamedTypeSymbol> exported = [.. extractor.ExtractAllExportedSymbols()];
+        Assert.That(exported.Select(s => s.Name), Does.Contain("C1"));
+    }
+}

--- a/src/TypeShim.Generator.Tests/Parsing/SyntaxTreeParsingTests_UnsupportedType.cs
+++ b/src/TypeShim.Generator.Tests/Parsing/SyntaxTreeParsingTests_UnsupportedType.cs
@@ -80,7 +80,6 @@ internal class SyntaxTreeParsingTests_UnsupportedType
     [TestCase("Task<int>")]
     [TestCase("Action")]
     [TestCase("Task<Action>")]
-    [TestCase("Task<Span<Byte>")]
     public void ClassInfoBuilder_Throws_ForUnsupportedTaskTypeArguments(string typeExpression)
     {
         SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText("""

--- a/src/TypeShim.Generator.Tests/TypeScript/TypeScriptUserClassProxyRendererTests_Char.cs
+++ b/src/TypeShim.Generator.Tests/TypeScript/TypeScriptUserClassProxyRendererTests_Char.cs
@@ -21,7 +21,7 @@ internal class TypeScriptUserClassProxyRendererTests_Char
             [TSExport]
             public class C1
             {
-                public char M1() {}
+                public char M1() { return default!; }
             }
         """);
 

--- a/src/TypeShim.Generator.Tests/TypeScript/TypeScriptUserClassProxyRendererTests_Delegates.cs
+++ b/src/TypeShim.Generator.Tests/TypeScript/TypeScriptUserClassProxyRendererTests_Delegates.cs
@@ -643,7 +643,7 @@ internal class TypeScriptUserClassProxyRendererTests_Delegates
         [TSExport]
         public class C1
         {
-            public Func<UserClass, UserClass?>? M1() {}
+            public Func<UserClass, UserClass?>? M1() { return default!; }
         }
         """);
 
@@ -694,7 +694,7 @@ internal class TypeScriptUserClassProxyRendererTests_Delegates
         [TSExport]
         public class C1
         {
-            public Func<UserClass, UserClass>? M1() {}
+            public Func<UserClass, UserClass>? M1() { return default!; }
         }
         """);
 
@@ -772,7 +772,7 @@ internal class TypeScriptUserClassProxyRendererTests_Delegates
         [TSExport]
         public class C1
         {
-            public Func<char> M1() {}
+            public Func<char> M1() { return default!; }
         }
         """);
 
@@ -811,7 +811,7 @@ internal class TypeScriptUserClassProxyRendererTests_Delegates
         [TSExport]
         public class C1
         {
-            public Action<char> M1() {}
+            public Action<char> M1() { return default!; }
         }
         """);
 
@@ -987,7 +987,7 @@ internal class TypeScriptUserClassProxyRendererTests_Delegates
         [TSExport]
         public class C1
         {
-            public Action<char, UserClass> M1() {}
+            public Action<char, UserClass> M1() { return default!; }
         }
         """);
 

--- a/src/TypeShim.Generator.Tests/TypeScript/TypeScriptUserClassProxyRendererTests_Methods.cs
+++ b/src/TypeShim.Generator.Tests/TypeScript/TypeScriptUserClassProxyRendererTests_Methods.cs
@@ -22,7 +22,7 @@ internal class TypeScriptUserClassProxyRendererTests_Methods
             [TSExport]
             public class C1
             {
-                public {{typeExpression}} DoP1() {}
+                public {{typeExpression}} DoP1() { return default!; }
             }
         """.Replace("{{typeExpression}}", typeExpression));
 
@@ -63,7 +63,7 @@ export class C1 extends ProxyBase {
             [TSExport]
             public class C1
             {
-                public {{typeExpression}} DoP1() {}
+                public {{typeExpression}} DoP1() { return default!; }
             }
         """.Replace("{{typeExpression}}", typeExpression));
 
@@ -113,7 +113,7 @@ export class C1 extends ProxyBase {
             [TSExport]
             public class C1
             {
-                public UserClass[] GetAll() {}
+                public UserClass[] GetAll() { return default!; }
             }
         """);
 
@@ -166,7 +166,7 @@ export class C1 extends ProxyBase {
             [TSExport]
             public class C1
             {
-                public UserClass? GetMaybe() {}
+                public UserClass? GetMaybe() { return default!; }
             }
         """);
 
@@ -610,7 +610,7 @@ export class C1 extends ProxyBase {
             [TSExport]
             public class C1(int i)
             {
-                public {{typeName}} M1() {}
+                public {{typeName}} M1() { return default!; }
                 public void M2({{typeName}} span) {}
             }
         """.Replace("{{typeName}}", typeName));

--- a/src/TypeShim.Generator.Tests/TypeScript/TypeScriptUserClassProxyRendererTests_ParameterlessConstructors.cs
+++ b/src/TypeShim.Generator.Tests/TypeScript/TypeScriptUserClassProxyRendererTests_ParameterlessConstructors.cs
@@ -21,7 +21,7 @@ internal class TypeScriptUserClassProxyRendererTests_ParameterlessConstructors
             [TSExport]
             public class C1()
             {
-                public {{typeExpression}} P1 { get; set }
+                public {{typeExpression}} P1 { get; set; }
             }
         """.Replace("{{typeExpression}}", typeExpression));
 

--- a/src/TypeShim.Generator.Tests/TypeScript/TypeScriptUserClassProxyRendererTests_Properties.cs
+++ b/src/TypeShim.Generator.Tests/TypeScript/TypeScriptUserClassProxyRendererTests_Properties.cs
@@ -166,7 +166,7 @@ export class C1 extends ProxyBase {
                 public static {{typeExpression}} P1 { get; set; }
                 public static {{typeExpression}} P2 { get; init; }
                 public static {{typeExpression}} P3 { get; }
-                public static {{typeExpression}} P4 => 1
+                public static {{typeExpression}} P4 => 1;
             }
         """.Replace("{{typeExpression}}", typeExpression));
 

--- a/src/TypeShim.Generator.Tests/TypeScript/TypescriptAssemblyExportsRendererTests.cs
+++ b/src/TypeShim.Generator.Tests/TypeScript/TypescriptAssemblyExportsRendererTests.cs
@@ -761,7 +761,7 @@ export interface AssemblyExports{
             [TSExport]
             public class C1
             {
-                public Func<UserClass> M1() {}
+                public Func<UserClass> M1() { return default!; }
             }
         """);
 
@@ -819,7 +819,7 @@ export interface AssemblyExports{
             [TSExport]
             public class C1
             {
-                public Func<UserClass, UserClass> M1() {}
+                public Func<UserClass, UserClass> M1() { return default!; }
             }
         """);
 
@@ -871,7 +871,7 @@ export interface AssemblyExports{
             [TSExport]
             public class C1(int i)
             {
-                public {{typeName}} M1() {}
+                public {{typeName}} M1() { return default!; }
                 public void M2({{typeName}} span) {}
             }
         """.Replace("{{typeName}}", typeName));

--- a/src/TypeShim.Generator/ExportedSignatureGate.cs
+++ b/src/TypeShim.Generator/ExportedSignatureGate.cs
@@ -113,13 +113,12 @@ internal static class ExportedSignatureGate
         }
     }
 
-    private static TypeShimException MakeException(Diagnostic diagnostic)
+    private static InvalidCodeException MakeException(Diagnostic diagnostic)
     {
         FileLinePositionSpan position = diagnostic.Location.GetLineSpan();
         int line = position.StartLinePosition.Line + 1;
         int column = position.StartLinePosition.Character + 1;
-        return new TypeShimException(
-            $"TypeShim found invalid code in '{position.Path}' ({line},{column}): {diagnostic.Id} {diagnostic.GetMessage()}. " +
-            "Fix the compile error and rebuild; no interop was generated.");
+        return new InvalidCodeException(
+            $"TypeShim codegen aborted: invalid code in '{position.Path}' ({line},{column}): {diagnostic.Id} {diagnostic.GetMessage()}.");
     }
 }

--- a/src/TypeShim.Generator/ExportedSignatureGate.cs
+++ b/src/TypeShim.Generator/ExportedSignatureGate.cs
@@ -1,0 +1,125 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using TypeShim.Shared;
+
+namespace TypeShim.Generator;
+
+internal static class ExportedSignatureGate
+{
+    // Name/type-availability diagnostics that are false positives in the partial compilation
+    // (missing refs / rewriter-stripped non-exported types or consts). These are reported with
+    // better, name-specific messages by the parser and the analyzer. CS0103 covers a default
+    // parameter value referencing a const declared in a stripped non-exported class.
+    private static readonly HashSet<string> IgnoredDiagnosticIds =
+        new(StringComparer.Ordinal) { "CS0246", "CS0234", "CS0122", "CS0103" };
+
+    internal static void ThrowIfExportedSurfaceHasCompileErrors(
+        CSharpCompilation compilation,
+        IReadOnlyList<INamedTypeSymbol> exportedSymbols)
+    {
+        ThrowIfHasSyntaxErrors(exportedSymbols);
+        ThrowIfHasSemanticErrors(compilation, exportedSymbols);
+    }
+
+    private static void ThrowIfHasSemanticErrors(CSharpCompilation compilation, IReadOnlyList<INamedTypeSymbol> exportedSymbols)
+    {
+        foreach (INamedTypeSymbol type in exportedSymbols)
+        {
+            foreach (ISymbol member in type.GetMembers())
+            {
+                if (member.DeclaredAccessibility != Accessibility.Public || member.IsImplicitlyDeclared)
+                {
+                    continue;
+                }
+
+                foreach (SyntaxReference syntaxReference in member.DeclaringSyntaxReferences)
+                {
+                    // Only check public signatures (return type, parameters, and constraints).
+                    // The body of the member is not relevant to the interop surface and actually
+                    // is very likely to contain many errors due to non TSExport symbol stripping (perf)
+                    if (!TryGetSignatureSpan(syntaxReference.GetSyntax(), out TextSpan span))
+                    {
+                        continue;
+                    }
+
+                    SemanticModel model = compilation.GetSemanticModel(syntaxReference.SyntaxTree);
+                    foreach (Diagnostic diagnostic in model.GetDiagnostics(span))
+                    {
+                        if (diagnostic.Severity == DiagnosticSeverity.Error && !IgnoredDiagnosticIds.Contains(diagnostic.Id))
+                        {
+                            throw MakeException(diagnostic);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void ThrowIfHasSyntaxErrors(IReadOnlyList<INamedTypeSymbol> exportedSymbols)
+    {
+        HashSet<SyntaxTree> declaringTrees = [];
+        foreach (INamedTypeSymbol symbol in exportedSymbols)
+        {
+            foreach (SyntaxReference syntaxReference in symbol.DeclaringSyntaxReferences)
+            {
+                declaringTrees.Add(syntaxReference.SyntaxTree);
+            }
+        }
+
+        foreach (SyntaxTree tree in declaringTrees)
+        {
+            foreach (Diagnostic diagnostic in tree.GetDiagnostics())
+            {
+                if (diagnostic.Severity == DiagnosticSeverity.Error)
+                {
+                    throw MakeException(diagnostic);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Signature span anchored at the return/element type (excludes attributes and modifiers) and
+    /// extending to the end of the parameter list, or the constraint clauses when present.
+    /// Constructors have no return type, so they anchor at the identifier. Returns <c>false</c> for
+    /// members that are not codegen inputs (fields, events, nested types, ...).
+    /// </summary>
+    private static bool TryGetSignatureSpan(SyntaxNode node, out TextSpan span)
+    {
+        switch (node)
+        {
+            case MethodDeclarationSyntax method:
+            {
+                int end = method.ConstraintClauses.Count > 0
+                    ? method.ConstraintClauses[^1].Span.End
+                    : method.ParameterList.Span.End;
+                span = TextSpan.FromBounds(method.ReturnType.SpanStart, end);
+                return true;
+            }
+            case ConstructorDeclarationSyntax constructor:
+                span = TextSpan.FromBounds(constructor.Identifier.SpanStart, constructor.ParameterList.Span.End);
+                return true;
+            case IndexerDeclarationSyntax indexer:
+                span = TextSpan.FromBounds(indexer.Type.SpanStart, indexer.ParameterList.Span.End);
+                return true;
+            case PropertyDeclarationSyntax property:
+                span = TextSpan.FromBounds(property.Type.SpanStart, property.Identifier.Span.End);
+                return true;
+            default:
+                span = default;
+                return false;
+        }
+    }
+
+    private static TypeShimException MakeException(Diagnostic diagnostic)
+    {
+        FileLinePositionSpan position = diagnostic.Location.GetLineSpan();
+        int line = position.StartLinePosition.Line + 1;
+        int column = position.StartLinePosition.Character + 1;
+        return new TypeShimException(
+            $"TypeShim found invalid code in '{position.Path}' ({line},{column}): {diagnostic.Id} {diagnostic.GetMessage()}. " +
+            "Fix the compile error and rebuild; no interop was generated.");
+    }
+}

--- a/src/TypeShim.Generator/SymbolExtractor.cs
+++ b/src/TypeShim.Generator/SymbolExtractor.cs
@@ -16,6 +16,7 @@ internal class SymbolExtractor(CSharpFileInfo[] fileInfos, string runtimePackRef
         CSharpCompilation compilation = CSharpPartialCompilation.CreatePartialCompilation(GetExportOnlyTrees(), runtimePackRefDir);
         List<INamedTypeSymbol> exportedSymbols = new(fileInfos.Length * 2); // should be enough space to avoid having to extend the list
         FindExports(compilation.Assembly.GlobalNamespace, exportedSymbols);
+        ExportedSignatureGate.ThrowIfExportedSurfaceHasCompileErrors(compilation, exportedSymbols);
         return exportedSymbols;
     }
 

--- a/src/TypeShim.Shared/Exceptions.cs
+++ b/src/TypeShim.Shared/Exceptions.cs
@@ -58,3 +58,7 @@ public class NotSupportedDefaultValueException(string message, Exception? innerE
 public class NotSupportedOptionalParameterException(string message, Exception? innerException = null) : TypeShimException(message, innerException)
 {
 }
+
+public class InvalidCodeException(string message, Exception? innerException = null) : TypeShimException(message, innerException)
+{
+}


### PR DESCRIPTION
If the compilation is going to fail, running codegen is potentially detrimental as at worst it can increase the number of errors a user gets and thus cause confusion and at best its useless as the code wont run anyway. 

To minimize risk this PR adds the following: analyze the compilation for syntax errors in the code being exported _and_ semantic errors in the signatures of exported members. If any compilation error pops up, abort. A few diagnostics codes are tolerated as existing guards downstream of the compilation stage in the generator have richer error messages, but ultimately the codegen is aborted in those cases as well.