### PR TITLE
chore: Test noop behavior of [CallerXX] and [OptionalXX] attributes

### DIFF
--- a/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_ParameterAttributes.cs
+++ b/src/TypeShim.Generator.Tests/CSharp/CSharpInteropClassRendererTests_ParameterAttributes.cs
@@ -1,0 +1,171 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TypeShim.Generator.CSharp;
+using TypeShim.Generator.Parsing;
+using TypeShim.Shared;
+
+namespace TypeShim.Generator.Tests.CSharp;
+
+internal class CSharpInteropClassRendererTests_ParameterAttributes
+{
+    private static string Render(string classBody)
+    {
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText($$"""
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            namespace N1;
+            [TSExport]
+            public class C1
+            {
+                private C1() {}
+            {{classBody}}
+            }
+        """);
+
+        SymbolExtractor symbolExtractor = new([CSharpFileInfo.Create(syntaxTree)], TestFixture.TargetingPackRefDir);
+        List<INamedTypeSymbol> exportedClasses = [.. symbolExtractor.ExtractAllExportedSymbols()];
+        Assert.That(exportedClasses, Has.Count.EqualTo(1));
+
+        InteropTypeInfoCache typeCache = new();
+        ClassInfo classInfo = new ClassInfoBuilder(exportedClasses[0], typeCache).Build();
+        RenderContext renderContext = new(classInfo, [classInfo], RenderOptions.CSharp);
+        return new CSharpInteropClassRenderer(classInfo, renderContext, new JSObjectMethodResolver([])).Render();
+    }
+
+    [Test]
+    public void OptionalAndDefaultParameterValue_InteropAlwaysPassesArgument()
+    {
+        string output = Render("    public void M1([Optional, DefaultParameterValue(19.99)] double price) {}");
+
+        AssertEx.EqualOrDiff(output, """
+#nullable enable
+// TypeShim generated TypeScript interop definitions
+using System;
+using System.Runtime.InteropServices.JavaScript;
+using System.Threading.Tasks;
+namespace N1;
+public partial class C1Interop
+{
+    [JSExport]
+    [return: JSMarshalAs<JSType.Void>]
+    public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.Number>] double price)
+    {
+        C1 typed_instance = C1Interop.FromObject(instance);
+        typed_instance.M1(price);
+    }
+    public static C1 FromObject(object obj)
+    {
+        return obj switch
+        {
+            C1 instance => instance,
+            _ => throw new ArgumentException($"Invalid object type {obj?.GetType().ToString() ?? "null"}", nameof(obj)),
+        };
+    }
+}
+
+""");
+    }
+
+    [Test]
+    public void CallerMemberName_InteropAlwaysPassesArgument()
+    {
+        string output = Render("    public void M1(string message, [CallerMemberName] string caller = \"\") {}");
+
+        AssertEx.EqualOrDiff(output, """
+#nullable enable
+// TypeShim generated TypeScript interop definitions
+using System;
+using System.Runtime.InteropServices.JavaScript;
+using System.Threading.Tasks;
+namespace N1;
+public partial class C1Interop
+{
+    [JSExport]
+    [return: JSMarshalAs<JSType.Void>]
+    public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.String>] string message, [JSMarshalAs<JSType.String>] string caller)
+    {
+        C1 typed_instance = C1Interop.FromObject(instance);
+        typed_instance.M1(message, caller);
+    }
+    public static C1 FromObject(object obj)
+    {
+        return obj switch
+        {
+            C1 instance => instance,
+            _ => throw new ArgumentException($"Invalid object type {obj?.GetType().ToString() ?? "null"}", nameof(obj)),
+        };
+    }
+}
+
+""");
+    }
+
+    [Test]
+    public void CallerLineNumber_InteropAlwaysPassesArgument()
+    {
+        string output = Render("    public void M1(string message, [CallerLineNumber] int line = 0) {}");
+
+        AssertEx.EqualOrDiff(output, """
+#nullable enable
+// TypeShim generated TypeScript interop definitions
+using System;
+using System.Runtime.InteropServices.JavaScript;
+using System.Threading.Tasks;
+namespace N1;
+public partial class C1Interop
+{
+    [JSExport]
+    [return: JSMarshalAs<JSType.Void>]
+    public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.String>] string message, [JSMarshalAs<JSType.Number>] int line)
+    {
+        C1 typed_instance = C1Interop.FromObject(instance);
+        typed_instance.M1(message, line);
+    }
+    public static C1 FromObject(object obj)
+    {
+        return obj switch
+        {
+            C1 instance => instance,
+            _ => throw new ArgumentException($"Invalid object type {obj?.GetType().ToString() ?? "null"}", nameof(obj)),
+        };
+    }
+}
+
+""");
+    }
+
+    [Test]
+    public void CallerArgumentExpression_InteropAlwaysPassesArgument()
+    {
+        string output = Render("    public void M1(string value, [CallerArgumentExpression(nameof(value))] string? expr = null) {}");
+
+        AssertEx.EqualOrDiff(output, """
+#nullable enable
+// TypeShim generated TypeScript interop definitions
+using System;
+using System.Runtime.InteropServices.JavaScript;
+using System.Threading.Tasks;
+namespace N1;
+public partial class C1Interop
+{
+    [JSExport]
+    [return: JSMarshalAs<JSType.Void>]
+    public static void M1([JSMarshalAs<JSType.Any>] object instance, [JSMarshalAs<JSType.String>] string value, [JSMarshalAs<JSType.String>] string? expr)
+    {
+        C1 typed_instance = C1Interop.FromObject(instance);
+        typed_instance.M1(value, expr);
+    }
+    public static C1 FromObject(object obj)
+    {
+        return obj switch
+        {
+            C1 instance => instance,
+            _ => throw new ArgumentException($"Invalid object type {obj?.GetType().ToString() ?? "null"}", nameof(obj)),
+        };
+    }
+}
+
+""");
+    }
+}

--- a/src/TypeShim.Generator.Tests/Parsing/SyntaxTreeParsingTests_ParameterAttributes.cs
+++ b/src/TypeShim.Generator.Tests/Parsing/SyntaxTreeParsingTests_ParameterAttributes.cs
@@ -1,0 +1,132 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TypeShim.Generator.Parsing;
+using TypeShim.Shared;
+
+namespace TypeShim.Generator.Tests.Parsing;
+
+internal class SyntaxTreeParsingTests_ParameterAttributes
+{
+    private static (ClassInfo Class, IParameterSymbol Symbol) GetParameter(string methodBody, string parameterName)
+    {
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText($$"""
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            namespace N1;
+            [TSExport]
+            public class C1
+            {
+                {{methodBody}}
+            }
+        """);
+
+        SymbolExtractor symbolExtractor = new([CSharpFileInfo.Create(syntaxTree)], TestFixture.TargetingPackRefDir);
+        List<INamedTypeSymbol> exportedClasses = [.. symbolExtractor.ExtractAllExportedSymbols()];
+        Assert.That(exportedClasses, Has.Count.EqualTo(1));
+        InteropTypeInfoCache typeCache = new();
+        ClassInfo classInfo = new ClassInfoBuilder(exportedClasses[0], typeCache).Build();
+
+        IParameterSymbol symbol = exportedClasses[0].GetMembers()
+            .OfType<IMethodSymbol>()
+            .First(m => m.MethodKind == MethodKind.Ordinary)
+            .Parameters.Single(p => p.Name == parameterName);
+
+        return (classInfo, symbol);
+    }
+
+    private static MethodParameterInfo Parsed(ClassInfo classInfo, string parameterName)
+        => classInfo.Methods.Single().Parameters.Single(p => p.Name == parameterName);
+
+    [Test]
+    public void OptionalAndDefaultParameterValue_DoesNotBindAndHasNoDefault()
+    {
+        (ClassInfo classInfo, IParameterSymbol symbol) = GetParameter(
+            "public void M1([Optional, DefaultParameterValue(19.99)] double price) { }",
+            "price");
+
+        Assert.That(symbol.HasExplicitDefaultValue, Is.False);
+        Assert.That(symbol.IsOptional, Is.False);
+        Assert.That(symbol.GetAttributes().Select(a => a.AttributeClass!.Kind), Is.All.EqualTo(SymbolKind.ErrorType));
+        Assert.That(Parsed(classInfo, "price").Default, Is.Null);
+    }
+
+    [Test]
+    public void OptionalAttributeAlone_DoesNotBindAndHasNoDefault()
+    {
+        (ClassInfo classInfo, IParameterSymbol symbol) = GetParameter(
+            "public void M1([Optional] double price) { }",
+            "price");
+
+        Assert.That(symbol.HasExplicitDefaultValue, Is.False);
+        Assert.That(symbol.IsOptional, Is.False);
+        Assert.That(symbol.GetAttributes().Select(a => a.AttributeClass!.Kind), Is.All.EqualTo(SymbolKind.ErrorType));
+        Assert.That(Parsed(classInfo, "price").Default, Is.Null);
+    }
+
+    [Test]
+    public void DefaultParameterValueWithoutOptional_DoesNotBindAndHasNoDefault()
+    {
+        (ClassInfo classInfo, IParameterSymbol symbol) = GetParameter(
+            "public void M1([DefaultParameterValue(19.99)] double price) { }",
+            "price");
+
+        Assert.That(symbol.HasExplicitDefaultValue, Is.False);
+        Assert.That(symbol.IsOptional, Is.False);
+        Assert.That(symbol.GetAttributes().Select(a => a.AttributeClass!.Kind), Is.All.EqualTo(SymbolKind.ErrorType));
+        Assert.That(Parsed(classInfo, "price").Default, Is.Null);
+    }
+
+    [Test]
+    public void CallerMemberName_BindsAndKeepsEmptyStringDefault()
+    {
+        (ClassInfo classInfo, IParameterSymbol symbol) = GetParameter(
+            "public void M1(string message, [CallerMemberName] string caller = \"\") { }",
+            "caller");
+
+        AttributeData attr = symbol.GetAttributes().Single();
+        Assert.That(attr.AttributeClass!.Name, Is.EqualTo("CallerMemberNameAttribute"));
+        Assert.That(attr.AttributeClass.Kind, Is.Not.EqualTo(SymbolKind.ErrorType));
+        Assert.That(symbol.HasExplicitDefaultValue, Is.True);
+
+        MethodParameterInfo parameter = Parsed(classInfo, "caller");
+        Assert.That(parameter.Default, Is.Not.Null);
+        Assert.That(parameter.Default!.Value, Is.EqualTo(string.Empty));
+        Assert.That(parameter.Default!.IsDefaultLiteral, Is.False);
+    }
+
+    [Test]
+    public void CallerLineNumber_BindsAndKeepsZeroDefault()
+    {
+        (ClassInfo classInfo, IParameterSymbol symbol) = GetParameter(
+            "public void M1(string message, [CallerLineNumber] int line = 0) { }",
+            "line");
+
+        AttributeData attr = symbol.GetAttributes().Single();
+        Assert.That(attr.AttributeClass!.Name, Is.EqualTo("CallerLineNumberAttribute"));
+        Assert.That(attr.AttributeClass.Kind, Is.Not.EqualTo(SymbolKind.ErrorType));
+        Assert.That(symbol.HasExplicitDefaultValue, Is.True);
+
+        MethodParameterInfo parameter = Parsed(classInfo, "line");
+        Assert.That(parameter.Default, Is.Not.Null);
+        Assert.That(parameter.Default!.Value, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void CallerArgumentExpression_BindsAndKeepsNullDefault()
+    {
+        (ClassInfo classInfo, IParameterSymbol symbol) = GetParameter(
+            "public void M1(string value, [CallerArgumentExpression(nameof(value))] string? expr = null) { }",
+            "expr");
+
+        AttributeData attr = symbol.GetAttributes().Single();
+        Assert.That(attr.AttributeClass!.Name, Is.EqualTo("CallerArgumentExpressionAttribute"));
+        Assert.That(attr.AttributeClass.Kind, Is.Not.EqualTo(SymbolKind.ErrorType));
+        Assert.That(symbol.HasExplicitDefaultValue, Is.True);
+
+        MethodParameterInfo parameter = Parsed(classInfo, "expr");
+        Assert.That(parameter.Default, Is.Not.Null);
+        Assert.That(parameter.Default!.Value, Is.Null);
+        Assert.That(parameter.Default!.IsDefaultLiteral, Is.False);
+    }
+}

--- a/src/TypeShim.Generator.Tests/TypeScript/TypeScriptUserClassProxyRendererTests_ParameterAttributes.cs
+++ b/src/TypeShim.Generator.Tests/TypeScript/TypeScriptUserClassProxyRendererTests_ParameterAttributes.cs
@@ -1,0 +1,202 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TypeShim.Generator.Parsing;
+using TypeShim.Generator.Typescript;
+using TypeShim.Shared;
+
+namespace TypeShim.Generator.Tests.TypeScript;
+
+internal class TypeScriptUserClassProxyRendererTests_ParameterAttributes
+{
+    private static string Render(string classBody)
+    {
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText($$"""
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Threading.Tasks;
+            namespace N1;
+            [TSExport]
+            public class C1
+            {
+            {{classBody}}
+            }
+        """);
+
+        SymbolExtractor symbolExtractor = new([CSharpFileInfo.Create(syntaxTree)], TestFixture.TargetingPackRefDir);
+        List<INamedTypeSymbol> exportedClasses = [.. symbolExtractor.ExtractAllExportedSymbols()];
+        Assert.That(exportedClasses, Has.Count.EqualTo(1));
+
+        InteropTypeInfoCache typeCache = new();
+        ClassInfo classInfo = new ClassInfoBuilder(exportedClasses[0], typeCache).Build();
+
+        RenderContext renderContext = new(classInfo, [classInfo], RenderOptions.TypeScript);
+        new TypescriptUserClassProxyRenderer(renderContext).Render();
+        return renderContext.ToString();
+    }
+
+    [Test]
+    public void OptionalAndDefaultParameterValue_RendersAsRequired()
+    {
+        string output = Render("    public void M1([Optional, DefaultParameterValue(19.99)] double price) {}");
+
+        AssertEx.EqualOrDiff(output, """
+export class C1 extends ProxyBase {
+  constructor() {
+    super(TypeShimConfig.exports.N1.C1Interop.ctor());
+  }
+
+  public M1(price: number): void {
+    TypeShimConfig.exports.N1.C1Interop.M1(this.instance, price);
+  }
+}
+
+""");
+    }
+
+    [Test]
+    public void OptionalAttributeAlone_RendersAsRequired()
+    {
+        string output = Render("    public void M1([Optional] double price) {}");
+
+        AssertEx.EqualOrDiff(output, """
+export class C1 extends ProxyBase {
+  constructor() {
+    super(TypeShimConfig.exports.N1.C1Interop.ctor());
+  }
+
+  public M1(price: number): void {
+    TypeShimConfig.exports.N1.C1Interop.M1(this.instance, price);
+  }
+}
+
+""");
+    }
+
+    [Test]
+    public void DefaultParameterValueWithoutOptional_RendersAsRequired()
+    {
+        string output = Render("    public void M1([DefaultParameterValue(19.99)] double price) {}");
+
+        AssertEx.EqualOrDiff(output, """
+export class C1 extends ProxyBase {
+  constructor() {
+    super(TypeShimConfig.exports.N1.C1Interop.ctor());
+  }
+
+  public M1(price: number): void {
+    TypeShimConfig.exports.N1.C1Interop.M1(this.instance, price);
+  }
+}
+
+""");
+    }
+
+    [Test]
+    public void CallerMemberName_RendersAsOrdinaryOptionalString()
+    {
+        string output = Render("    public void M1(string message, [CallerMemberName] string caller = \"\") {}");
+
+        AssertEx.EqualOrDiff(output, """
+export class C1 extends ProxyBase {
+  constructor() {
+    super(TypeShimConfig.exports.N1.C1Interop.ctor());
+  }
+
+  public M1(message: string, caller: string = ""): void {
+    TypeShimConfig.exports.N1.C1Interop.M1(this.instance, message, caller);
+  }
+}
+
+""");
+    }
+
+    [Test]
+    public void CallerMemberName_NullableNullDefault_RendersAsOptionalNull()
+    {
+        string output = Render("    public void M1(string message, [CallerMemberName] string? caller = null) {}");
+
+        AssertEx.EqualOrDiff(output, """
+export class C1 extends ProxyBase {
+  constructor() {
+    super(TypeShimConfig.exports.N1.C1Interop.ctor());
+  }
+
+  public M1(message: string, caller: string | null = null): void {
+    TypeShimConfig.exports.N1.C1Interop.M1(this.instance, message, caller);
+  }
+}
+
+""");
+    }
+
+    [Test]
+    public void CallerLineNumber_RendersAsOrdinaryOptionalInt()
+    {
+        string output = Render("    public void M1(string message, [CallerLineNumber] int line = 0) {}");
+
+        AssertEx.EqualOrDiff(output, """
+export class C1 extends ProxyBase {
+  constructor() {
+    super(TypeShimConfig.exports.N1.C1Interop.ctor());
+  }
+
+  public M1(message: string, line: number = 0): void {
+    TypeShimConfig.exports.N1.C1Interop.M1(this.instance, message, line);
+  }
+}
+
+""");
+    }
+
+    [Test]
+    public void CallerArgumentExpression_RendersAsOrdinaryOptionalString()
+    {
+        string output = Render("    public void M1(string value, [CallerArgumentExpression(nameof(value))] string? expr = null) {}");
+
+        AssertEx.EqualOrDiff(output, """
+export class C1 extends ProxyBase {
+  constructor() {
+    super(TypeShimConfig.exports.N1.C1Interop.ctor());
+  }
+
+  public M1(value: string, expr: string | null = null): void {
+    TypeShimConfig.exports.N1.C1Interop.M1(this.instance, value, expr);
+  }
+}
+
+""");
+    }
+
+    [Test]
+    public void OptionalAndDefaultParameterValue_OnConstructor_RendersAsRequired()
+    {
+        string output = Render("    public C1([Optional, DefaultParameterValue(19.99)] double price) {}");
+
+        AssertEx.EqualOrDiff(output, """
+export class C1 extends ProxyBase {
+  constructor(price: number) {
+    super(TypeShimConfig.exports.N1.C1Interop.ctor(price));
+  }
+
+}
+
+""");
+    }
+
+    [Test]
+    public void CallerMemberName_OnConstructor_RendersAsOrdinaryOptionalString()
+    {
+        string output = Render("    public C1([CallerMemberName] string caller = \"\") {}");
+
+        AssertEx.EqualOrDiff(output, """
+export class C1 extends ProxyBase {
+  constructor(caller: string = "") {
+    super(TypeShimConfig.exports.N1.C1Interop.ctor(caller));
+  }
+
+}
+
+""");
+    }
+}


### PR DESCRIPTION
Add test coverage demonstrating expected behavior for interop irrelevant parameter attributes.

They are effectively ignored.